### PR TITLE
pip: Properly lookup source version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ py_dict
 /ci-venv/
 /ci-logs*
 .eggs
-src/fprime-tools.egg-info
+src/fprime_tools.egg-info
 **/DefaultDict/serializable/*
 /.idea/
 /venv/

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 # pip install -e ./Fw/Python
 # ```
 ###
-import os
 from setuptools import find_packages, setup
 
 # Setup a python package using setup-tools. This is a newer (and more recommended) technology
@@ -30,7 +29,7 @@ setup(
     ####
     name="fprime-tools",
     use_scm_version={
-        "root": os.path.join("..", ".."),
+        "root": ".",
         "relative_to": __file__,
     },
     license="Apache 2.0 License",


### PR DESCRIPTION
Fixes errors when trying to install pip package with `pip install -e`