### PR TITLE
Verify target exists before building

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -360,6 +360,14 @@ class Build:
             "auto_location": auto_location,
         }
 
+    def check_target(self, cwd: Path, target: Target):
+        if isinstance(target, GlobalTarget):
+            return
+
+        valid_cmake_targets = self.cmake.get_available_targets(self.build_dir, cwd)
+        if target.cmake_target not in valid_cmake_targets:
+            raise NoSuchTargetException("Target '{}' does not exist in current directory".format(target))
+
     def find_toolchain(self):
         """Locates a toolchain file in know locations
 

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -393,6 +393,8 @@ def utility_entry(args):
             target = get_target(parsed)
             build = Build(target.build_type, deployment, verbose=parsed.verbose)
             build.load(cwd, parsed.platform)
+            # Verify that matched target actually exists
+            build.check_target(cwd, target)
             build.execute(target, context=Path(parsed.path), make_args=make_args)
     except GenerateException as genex:
         print(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Before attempting to build a target, verify that the target actually exists.

## Rationale

There are some cases where local targets don't exist in a particular directory (Try `fprime-util build` in the root of the fprime repo for example`). Right now, this isn't caught and fprime-util prints a cmake usage message with no error details.

Target lookup now looks like this:

- Lookup target in list of all possible targets
- Use target to determine build type to load
- Load build
- Check if local target actually exists within loaded build