### PR TITLE
Don't supply empty cmake target

### DIFF
--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -106,7 +106,11 @@ class CMakeHandler:
         environment = {} if environment is None else copy.copy(environment)
         if self.verbose:
             environment["VERBOSE"] = "1"
-        run_args.extend(["--target", cmake_target])
+
+        # The cmake target is "" when running build in the root of the F' repo.
+        if cmake_target != "":
+            run_args.extend(["--target", cmake_target])
+
         try:
             return self._run_cmake(
                 run_args + fleshed_args, write_override=True, environment=environment


### PR DESCRIPTION


| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Rationale

An empty target occurs when building the root of fprime.
Newer versions of cmake treat an empty target argument as an error.
Instead, pass no target, which will build the default cmake target "all".
## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Testing Notes

Run `fprime-util build` in the root of fprime.
