### PR TITLE
lestarch: fixing absolute vs relative path in CMake cache check

### DIFF
--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -78,7 +78,7 @@ class IniSettings:
         """
         settings_file = (
             settings_file if settings_file is not None else Path(IniSettings.DEF_FILE)
-        )
+        ).resolve()
 
         dfl_install_dest = Path(settings_file.resolve().parent, "build-artifacts")
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The CMake cache consistency check breaks when one uses the `-p` argument because the settings.ini file path becomes a relative path.  This fix "resolves" it by resolving the path.