### PR TITLE
lestarch: allowing int inputs to floats

### DIFF
--- a/src/fprime/common/models/serialize/numerical_types.py
+++ b/src/fprime/common/models/serialize/numerical_types.py
@@ -80,7 +80,7 @@ class FloatType(NumericalType, abc.ABC):
 
     def validate(self, val):
         """Validates the given integer."""
-        if not isinstance(val, float):
+        if not isinstance(val, (float, int)):
             raise TypeMismatchException(float, type(val))
 
 

--- a/test/fprime/common/models/serialize/test_types.py
+++ b/test/fprime/common/models/serialize/test_types.py
@@ -206,10 +206,12 @@ def test_float_types_nominal():
 def test_float_types_off_nominal():
     """Tests the integer off nominal types"""
     invalid_values_test(
-        F32Type, filter(lambda item: not isinstance(item, float), PYTHON_TESTABLE_TYPES)
+        F32Type,
+        filter(lambda item: not isinstance(item, (float, int)), PYTHON_TESTABLE_TYPES),
     )
     invalid_values_test(
-        F64Type, filter(lambda item: not isinstance(item, float), PYTHON_TESTABLE_TYPES)
+        F64Type,
+        filter(lambda item: not isinstance(item, (float, int)), PYTHON_TESTABLE_TYPES),
     )
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Int should be allowed as arguments to float as ints are a subclass of floats.