### PR TITLE
saba-ja: added formatted_val for serializable and array types

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -13,6 +13,7 @@ from .type_exceptions import (
 )
 
 from . import serializable_type
+from fprime.util.string_util import format_string_template
 
 
 class ArrayType(ValueType):
@@ -69,10 +70,12 @@ class ArrayType(ValueType):
         """
         result = []
         for item in self.__val:
-            if isinstance(item, serializable_type.SerializableType):
+            if isinstance(item, (
+                serializable_type.SerializableType, ArrayType)):
                 result.append(item.formatted_val)
             else:
-                result.append(self.__arr_format % item.val)
+                result.append(
+                    format_string_template(self.__arr_format, item.val))
         return result
 
     @val.setter

--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -14,6 +14,7 @@ from .type_exceptions import (
 
 from . import serializable_type
 
+
 class ArrayType(ValueType):
     """Generic fixed-size array type representation.
 

--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -70,12 +70,10 @@ class ArrayType(ValueType):
         """
         result = []
         for item in self.__val:
-            if isinstance(item, (
-                serializable_type.SerializableType, ArrayType)):
+            if isinstance(item, (serializable_type.SerializableType, ArrayType)):
                 result.append(item.formatted_val)
             else:
-                result.append(
-                    format_string_template(self.__arr_format, item.val))
+                result.append(format_string_template(self.__arr_format, item.val))
         return result
 
     @val.setter

--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -12,6 +12,7 @@ from .type_exceptions import (
     TypeMismatchException,
 )
 
+from . import serializable_type
 
 class ArrayType(ValueType):
     """Generic fixed-size array type representation.
@@ -56,6 +57,22 @@ class ArrayType(ValueType):
         :return dictionary of member names to python values of member keys
         """
         return [item.val for item in self.__val]
+
+    @property
+    def formatted_val(self) -> list:
+        """
+        Format all the elements of array according to the arr_format.
+        Note 1: All elements will be cast to str
+        Note 2: If a member is a serializable will call serializable formatted_val
+        :return a formatted array
+        """
+        result = []
+        for item in self.__val:
+            if isinstance(item, serializable_type.SerializableType):
+                result.append(item.formatted_val)
+            else:
+                result.append(self.__arr_format % item.val)
+        return result
 
     @val.setter
     def val(self, val: list):

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -11,6 +11,7 @@ from .type_exceptions import NotInitializedException, TypeMismatchException
 
 from . import array_type
 
+
 class SerializableType(ValueType):
     """
     Representation of the Serializable type (comparable to the ANY type)

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -9,6 +9,7 @@ import copy
 from .type_base import BaseType, ValueType
 from .type_exceptions import NotInitializedException, TypeMismatchException
 
+from . import array_type
 
 class SerializableType(ValueType):
     """
@@ -114,6 +115,22 @@ class SerializableType(ValueType):
             member_name: member_val.val
             for member_name, member_val, _, _ in self.mem_list
         }
+
+    @property
+    def formatted_val(self) -> dict:
+        """
+        Format all the members of dict according to the member_format.
+        Note 1: All elements will be cast to str
+        Note 2: If a member is an array will call array formatted_val
+        :return a formatted dict
+        """
+        result = dict()
+        for member_name, member_val, member_format, _ in self.mem_list:
+            if isinstance(member_val, array_type.ArrayType):
+                result[member_name] = member_val.formatted_val
+            else:
+                result[member_name] = member_format % member_val.val
+        return result
 
     @val.setter
     def val(self, val: dict):

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -131,7 +131,9 @@ class SerializableType(ValueType):
             if isinstance(member_val, (array_type.ArrayType, SerializableType)):
                 result[member_name] = member_val.formatted_val
             else:
-                result[member_name] = format_string_template(member_format, member_val.val)
+                result[member_name] = format_string_template(
+                    member_format, member_val.val
+                )
         return result
 
     @val.setter

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -10,6 +10,7 @@ from .type_base import BaseType, ValueType
 from .type_exceptions import NotInitializedException, TypeMismatchException
 
 from . import array_type
+from fprime.util.string_util import format_string_template
 
 
 class SerializableType(ValueType):
@@ -127,10 +128,10 @@ class SerializableType(ValueType):
         """
         result = dict()
         for member_name, member_val, member_format, _ in self.mem_list:
-            if isinstance(member_val, array_type.ArrayType):
+            if isinstance(member_val, (array_type.ArrayType, SerializableType)):
                 result[member_name] = member_val.formatted_val
             else:
-                result[member_name] = member_format % member_val.val
+                result[member_name] = format_string_template(member_format, member_val.val)
         return result
 
     @val.setter

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -40,6 +40,7 @@ def format_string_template(format_str, given_values):
 
     `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
     """
+
     def convert(match_obj, ignore_int):
         if match_obj.group() is not None:
             flags, width, precision, length, conversion_type = match_obj.groups()
@@ -78,7 +79,7 @@ def format_string_template(format_str, given_values):
 
     # Allowing single, list and tuple inputs
     if not isinstance(given_values, (list, tuple)):
-        values = (given_values, )
+        values = (given_values,)
     elif isinstance(given_values, list):
         values = tuple(given_values)
     else:
@@ -87,15 +88,16 @@ def format_string_template(format_str, given_values):
     pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
 
     match = re.compile(pattern)
-    
+
     # First try to include all types
     try:
-        formated_str = re.sub(match, convert_include_all, format_str)
-        result = formated_str.format(*values)
+        formatted_str = re.sub(match, convert_include_all, format_str)
+        result = formatted_str.format(*values)
         result = result.replace('%%', '%')
         return result
     except ValueError as e:
-        msg = 'Value and format string do not match. Will ignore integer flags `d` in string template. '
+        msg = 'Value and format string do not match. '
+        msg += ' Will ignore integer flags `d` in string template. '
         msg += f'values: {values}. '
         msg += f'format_str: {format_str}. '
         LOGGER.warning(msg)
@@ -104,8 +106,8 @@ def format_string_template(format_str, given_values):
     # This will resolve failing ENUMs with %d
     # but will fail on other types.
     try:
-        formated_str = re.sub(match, convert_ignore_int, format_str)
-        result = formated_str.format(*values)
+        formatted_str = re.sub(match, convert_ignore_int, format_str)
+        result = formatted_str.format(*values)
         result = result.replace('%%', '%')
         return result
     except ValueError as e:

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -1,0 +1,115 @@
+"""
+string_util.py
+Utility functions to process strings to be used in FPrime GDS
+@Created March 18, 2021
+@janamian
+"""
+
+import re
+import logging
+
+LOGGER = logging.getLogger('string_util_logger')
+
+
+def format_string_template(format_str, given_values):
+    """
+    Function to convert C-string style to python format
+    without using python interpolation
+    Considered the following format for C-string:
+    %[flags][width][.precision][length]type
+    
+    0- %:                (?<!%)(?:%%)*%
+    1- flags:            ([\-\+0\ \#])?
+    2- width:            (\d+|\*)?
+    3- .precision:       (\.\*|\.\d+)?
+    4- length:          `([hLIw]|l{1,2}|I32|I64)?`
+    5- conversion_type: `([cCdiouxXeEfgGaAnpsSZ])`
+    
+    Note:
+    This function will keep the flags, width, and .precision of C-string
+    template. 
+    
+    It will keep f, d, x, o, and e flags and remove all other types.
+    Other types will be duck-typed by python 
+    interpreter. 
+    
+    lengths will also be removed since they are not meaningful to Python interpreter.
+    `See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting`
+    
+    `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
+    """
+    def convert(match_obj, ignore_int):
+        if match_obj.group() is not None:
+            flags, width, precision, length, conversion_type = match_obj.groups()
+            format_template = ''
+            if flags:
+                format_template += f'{flags}'
+            if width:
+                format_template += f'{width}'
+            if precision:
+                format_template += f'{precision}'
+
+            if conversion_type:
+                if any([
+                    str(conversion_type).lower() == 'f',
+                    str(conversion_type).lower() == 'x',
+                    str(conversion_type).lower() == 'o',
+                    str(conversion_type).lower() == 'e',
+                    ]):
+                    format_template += f'{conversion_type}'
+                elif all([not ignore_int,
+                        str(conversion_type).lower() == 'd']):
+                    format_template += f'{conversion_type}'
+     
+            if format_template == '':
+                template = '{}'
+            else:
+                template = '{:' + format_template + '}'
+            return template
+        return match_obj
+
+    def convert_include_all(match_obj):
+        return convert(match_obj, ignore_int=False)
+
+    def convert_ignore_int(match_obj):
+        return convert(match_obj, ignore_int=True)
+    
+
+    # Allowing single, list and tuple inputs
+    if not isinstance(given_values, (list, tuple)):
+        values = (given_values, )
+    elif isinstance(given_values, list):
+        values = tuple(given_values)
+    else:
+        values = given_values
+
+    pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
+
+    match = re.compile(pattern)
+    # First try to include all types
+    try:
+        formated_str = re.sub(match, convert_include_all, format_str)
+        result = formated_str.format(*values)
+        result = result.replace('%%', '%')
+        return result
+    except ValueError as e:
+        msg = 'Value and format string do not match. Will ignore integer flags `d` in string template. '
+        msg += f'values: {values}. '
+        msg += f'format_str: {format_str}. '
+        LOGGER.warning(msg)
+        
+    # Second try by not including %d. 
+    # This will resolve failing ENUMs with %d
+    # but will fail on other types.
+    try:
+        formated_str = re.sub(match, convert_ignore_int, format_str)
+        result = formated_str.format(*values)
+        result = result.replace('%%', '%')
+        return result
+    except ValueError as e:
+        msg = 'Value and format string do not match. '
+        msg += f'values: {values}. '
+        msg += f'format_str: {format_str}. '
+        msg += f'Err Msg: {str(e)}\n'
+        LOGGER.error(msg)
+        raise ValueError

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -2,7 +2,7 @@
 string_util.py
 Utility functions to process strings to be used in FPrime GDS
 @Created March 18, 2021
-@janamian
+@`janamian`
 
 Note: This function has an identical copy in fprime-gds
 """
@@ -19,25 +19,25 @@ def format_string_template(format_str, given_values):
     without using python interpolation
     Considered the following format for C-string:
     %[flags][width][.precision][length]type
-    
+
     0- %:                (?<!%)(?:%%)*%
     1- flags:            ([\-\+0\ \#])?
     2- width:            (\d+|\*)?
     3- .precision:       (\.\*|\.\d+)?
     4- length:          `([hLIw]|l{1,2}|I32|I64)?`
     5- conversion_type: `([cCdiouxXeEfgGaAnpsSZ])`
-    
+
     Note:
     This function will keep the flags, width, and .precision of C-string
     template. 
-    
+
     It will keep f, d, x, o, and e flags and remove all other types.
     Other types will be duck-typed by python 
     interpreter. 
-    
+
     lengths will also be removed since they are not meaningful to Python interpreter.
     `See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting`
-    
+
     `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
     """
     def convert(match_obj, ignore_int):
@@ -57,12 +57,12 @@ def format_string_template(format_str, given_values):
                     str(conversion_type).lower() == 'x',
                     str(conversion_type).lower() == 'o',
                     str(conversion_type).lower() == 'e',
-                    ]):
+                ]):
                     format_template += f'{conversion_type}'
                 elif all([not ignore_int,
-                        str(conversion_type).lower() == 'd']):
+                          str(conversion_type).lower() == 'd']):
                     format_template += f'{conversion_type}'
-     
+
             if format_template == '':
                 template = '{}'
             else:
@@ -75,7 +75,6 @@ def format_string_template(format_str, given_values):
 
     def convert_ignore_int(match_obj):
         return convert(match_obj, ignore_int=True)
-    
 
     # Allowing single, list and tuple inputs
     if not isinstance(given_values, (list, tuple)):
@@ -88,6 +87,7 @@ def format_string_template(format_str, given_values):
     pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
 
     match = re.compile(pattern)
+    
     # First try to include all types
     try:
         formated_str = re.sub(match, convert_include_all, format_str)
@@ -99,8 +99,8 @@ def format_string_template(format_str, given_values):
         msg += f'values: {values}. '
         msg += f'format_str: {format_str}. '
         LOGGER.warning(msg)
-        
-    # Second try by not including %d. 
+
+    # Second try by not including %d.
     # This will resolve failing ENUMs with %d
     # but will fail on other types.
     try:

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -10,7 +10,7 @@ Note: This function has an identical copy in fprime-gds
 import re
 import logging
 
-LOGGER = logging.getLogger('string_util_logger')
+LOGGER = logging.getLogger("string_util_logger")
 
 
 def format_string_template(format_str, given_values):
@@ -29,11 +29,11 @@ def format_string_template(format_str, given_values):
 
     Note:
     This function will keep the flags, width, and .precision of C-string
-    template. 
+    template.
 
     It will keep f, d, x, o, and e flags and remove all other types.
-    Other types will be duck-typed by python 
-    interpreter. 
+    Other types will be duck-typed by python
+    interpreter.
 
     lengths will also be removed since they are not meaningful to Python interpreter.
     `See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting`
@@ -44,30 +44,31 @@ def format_string_template(format_str, given_values):
     def convert(match_obj, ignore_int):
         if match_obj.group() is not None:
             flags, width, precision, length, conversion_type = match_obj.groups()
-            format_template = ''
+            format_template = ""
             if flags:
-                format_template += f'{flags}'
+                format_template += f"{flags}"
             if width:
-                format_template += f'{width}'
+                format_template += f"{width}"
             if precision:
-                format_template += f'{precision}'
+                format_template += f"{precision}"
 
             if conversion_type:
-                if any([
-                    str(conversion_type).lower() == 'f',
-                    str(conversion_type).lower() == 'x',
-                    str(conversion_type).lower() == 'o',
-                    str(conversion_type).lower() == 'e',
-                ]):
-                    format_template += f'{conversion_type}'
-                elif all([not ignore_int,
-                          str(conversion_type).lower() == 'd']):
-                    format_template += f'{conversion_type}'
+                if any(
+                    [
+                        str(conversion_type).lower() == "f",
+                        str(conversion_type).lower() == "x",
+                        str(conversion_type).lower() == "o",
+                        str(conversion_type).lower() == "e",
+                    ]
+                ):
+                    format_template += f"{conversion_type}"
+                elif all([not ignore_int, str(conversion_type).lower() == "d"]):
+                    format_template += f"{conversion_type}"
 
-            if format_template == '':
-                template = '{}'
+            if format_template == "":
+                template = "{}"
             else:
-                template = '{:' + format_template + '}'
+                template = "{:" + format_template + "}"
             return template
         return match_obj
 
@@ -85,7 +86,7 @@ def format_string_template(format_str, given_values):
     else:
         values = given_values
 
-    pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
+    pattern = "(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])"
 
     match = re.compile(pattern)
 
@@ -93,13 +94,13 @@ def format_string_template(format_str, given_values):
     try:
         formatted_str = re.sub(match, convert_include_all, format_str)
         result = formatted_str.format(*values)
-        result = result.replace('%%', '%')
+        result = result.replace("%%", "%")
         return result
     except ValueError as e:
-        msg = 'Value and format string do not match. '
-        msg += ' Will ignore integer flags `d` in string template. '
-        msg += f'values: {values}. '
-        msg += f'format_str: {format_str}. '
+        msg = "Value and format string do not match. "
+        msg += " Will ignore integer flags `d` in string template. "
+        msg += f"values: {values}. "
+        msg += f"format_str: {format_str}. "
         LOGGER.warning(msg)
 
     # Second try by not including %d.
@@ -108,12 +109,12 @@ def format_string_template(format_str, given_values):
     try:
         formatted_str = re.sub(match, convert_ignore_int, format_str)
         result = formatted_str.format(*values)
-        result = result.replace('%%', '%')
+        result = result.replace("%%", "%")
         return result
     except ValueError as e:
-        msg = 'Value and format string do not match. '
-        msg += f'values: {values}. '
-        msg += f'format_str: {format_str}. '
-        msg += f'Err Msg: {str(e)}\n'
+        msg = "Value and format string do not match. "
+        msg += f"values: {values}. "
+        msg += f"format_str: {format_str}. "
+        msg += f"Err Msg: {str(e)}\n"
         LOGGER.error(msg)
         raise ValueError

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -3,6 +3,8 @@ string_util.py
 Utility functions to process strings to be used in FPrime GDS
 @Created March 18, 2021
 @janamian
+
+Note: This function has an identical copy in fprime-gds
 """
 
 import re


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F' Tools 2.0 |
|**_Affected Component_**| serializable_type, array_type |
|**_Affected Architectures(s)_**| NA |
|**_Related Issue(s)_**| https://github.com/fprime-community/fprime-gds/pull/27 |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| No |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Format serializable members and array elements based on the given format.

## Rationale

Currently serializable and array objects are only formatted as str without formatting members or elements of the object.
This PR adds a formatted_val property to serializable and array types.
The formatted_val will iterate all members of object and format them based on the given str format.

Note 1: All elements will be cast to str
Note 2: If a member of a serializable is an array it will call array formatted_val
Note 3: If an element of an array is a serializable it will call serializable formatted_val

## Testing/Review Recommendations

Manually tested on F Prime Ref.

Before format:
![Screen Shot 2021-08-18 at 4 15 23 AM](https://user-images.githubusercontent.com/35859004/129888849-7626cfe7-5e45-4ae1-bc71-800fedab0ccf.png)

After format:
![Screen Shot 2021-08-18 at 3 57 38 AM](https://user-images.githubusercontent.com/35859004/129888296-7379d174-f3c3-4cb8-a1de-8eee869a8508.png)

Note: This PR should be merged before GDS [PR 27](https://github.com/fprime-community/fprime-gds/pull/27) to avoid code break.

## Future Work

Might be a good idea to find a better way to display complex tlm values in the HTML table. The raw text view is hard to follow.
