### PR TITLE
Time port

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/post_gen_project.py
@@ -113,6 +113,11 @@ def update_sdd(component_kind, commands, parameters, events, telemetry):
         )
     else:
         remove_line("docs/sdd.md", "## Telemetry\n")
+    
+    ports = ports + textwrap.dedent(
+            """\
+            | timeGetOut | Used to pass time stamps around the system |\n"""
+        )
     replace_contents("docs/sdd.md", "## Port Descriptions", ports)
 
 

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/post_gen_project.py
@@ -113,11 +113,11 @@ def update_sdd(component_kind, commands, parameters, events, telemetry):
         )
     else:
         remove_line("docs/sdd.md", "## Telemetry\n")
-    
+
     ports = ports + textwrap.dedent(
-            """\
+        """\
             | timeGetOut | Used to pass time stamps around the system |\n"""
-        )
+    )
     replace_contents("docs/sdd.md", "## Port Descriptions", ports)
 
 

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/{{cookiecutter.component_name}}ComponentAi.xml
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/{{cookiecutter.component_name}}ComponentAi.xml
@@ -21,6 +21,8 @@
     <import_port_type>Fw/Prm/PrmGetPortAi.xml</import_port_type>
     <import_port_type>Fw/Prm/PrmSetPortAi.xml</import_port_type>
 {% endif %}
+    <!-- Import time port -->
+    <import_port_type>Fw/Time/TimePortAi.xml</import_port_type>
 {% if cookiecutter.component_kind != "passive" %}
     <!-- Import ping port -->
     <import_port_type>Svc/Ping/PingPortAi.xml</import_port_type>
@@ -61,6 +63,9 @@
         <port name="prmGetOut" data_type="Fw::PrmGet" kind="output" max_number="1">
         </port>
         <port name="prmSetOut" data_type="Fw::PrmSet" kind="output" max_number="1">
+        <!-- Time port-->
+        </port>
+        <port name="timeGetOut" data_type="Fw::Time" kind="output" max_number="1">
         </port>
 {% endif %}
 {%- if cookiecutter.component_kind != 'passive' %}

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/{{cookiecutter.component_name}}ComponentAi.xml
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/{{cookiecutter.component_name}}ComponentAi.xml
@@ -63,7 +63,7 @@
         <port name="prmGetOut" data_type="Fw::PrmGet" kind="output" max_number="1">
         </port>
         <port name="prmSetOut" data_type="Fw::PrmSet" kind="output" max_number="1">
-        <!-- Time port-->
+        <!-- Time port: to pass around time stamps -->
         </port>
         <port name="timeGetOut" data_type="Fw::Time" kind="output" max_number="1">
         </port>

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/{{cookiecutter.component_name}}ComponentAi.xml
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/{{cookiecutter.component_name}}ComponentAi.xml
@@ -63,11 +63,11 @@
         <port name="prmGetOut" data_type="Fw::PrmGet" kind="output" max_number="1">
         </port>
         <port name="prmSetOut" data_type="Fw::PrmSet" kind="output" max_number="1">
-        <!-- Time port: to pass around time stamps -->
-        </port>
-        <port name="timeGetOut" data_type="Fw::Time" kind="output" max_number="1">
         </port>
 {% endif %}
+        <!-- Time port: to pass around time stamps -->        
+        <port name="timeGetOut" data_type="Fw::Time" kind="output" max_number="1">
+        </port>
 {%- if cookiecutter.component_kind != 'passive' %}
         <!-- Input ping port -->
         <port name="pingIn" data_type="Svc::Ping" kind="async_input" max_number="1">


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Aidan Wagner |
|**_Affected Component_**| Cookiecutter |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added time port to cookiecutter template

## Rationale

The time port is used in interactions with commands, telemetry, events, and parameters
