### PR TITLE
Re-enable 'build --all --ut' command to build unit tests

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -590,6 +590,13 @@ BUILD_TARGETS = [
         flags={"ut"},
         cmake="ut_exe",
     ),
+    GlobalTarget(
+        "build",
+        "Build all unit tests",
+        build_type=BuildType.BUILD_TESTING,
+        flags={"all", "ut"},
+        cmake="all",
+    ),
     # Implementation targets
     LocalTarget("impl", "Generate implementation template files"),
     LocalTarget("impl", "Generate unit test files", flags={"ut"}, cmake="testimpl"),


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

`fprime-util` used to have a `build --all --ut` target to build all your unit tests. This PR re-exposes that target to fprime-util.

