### PR TITLE
Fix fprime-util hash-to-file

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,13 +28,16 @@ jobs:
       - name: Generate correct fprime version in gps-tutorial
         working-directory: gps-tutorial
         run: git submodule update --recursive
+      # 0x72ad3277 is Fw/Types/Assert.cpp, a file that should be consistent across releases
       - name: Test generation and building on Ref
         working-directory: fprime/Ref
         run: |
           fprime-util generate
           fprime-util build
+          fprime-util hash-to-file 0x72ad3277
       - name: Test generation and building on gps-tutorial
         working-directory: gps-tutorial/GpsApp
         run: |
           fprime-util generate
           fprime-util build
+          fprime-util hash-to-file 0x72ad3277

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -314,10 +314,11 @@ def print_hash_info(lines, hash_val):
         print("[INFO] File(s) associated with hash 0x{:x}".format(hash_val))
         for line in lines:
             print("   ", line, end="")
-        return
+        return 0
     print(
         "[ERROR] No file hashes found in {} build. Do you need '--build-type Testing' for a unittest run?"
     )
+    return 1
 
 
 def utility_entry(args):
@@ -347,13 +348,9 @@ def utility_entry(args):
             if parsed.component and parsed.port:
                 print("[ERROR] Use --component or --port, not both.")
             elif parsed.component:
-                status = new_component(
-                    deployment, parsed.platform, parsed.verbose, build
-                )
-                sys.exit(status)
+                return new_component(deployment, parsed.platform, parsed.verbose, build)
             elif parsed.port:
-                status = new_port(cwd, deployment, build)
-                sys.exit(status)
+                return new_port(cwd, deployment, build)
             else:
                 print(
                     "[ERROR] Specify whether you would like to generate a component or a port."
@@ -361,8 +358,9 @@ def utility_entry(args):
                 print("Use --component or --port.")
         elif parsed.command == "hash-to-file":
             build = Build(build_type, deployment, verbose=parsed.verbose)
+            build.load(cwd, parsed.platform)
             lines = build.find_hashed_file(parsed.hash)
-            print_hash_info(lines, parsed.hash)
+            return print_hash_info(lines, parsed.hash)
         elif parsed.command == "generate":
             build = Build(build_type, deployment, verbose=parsed.verbose)
             build.invent(cwd, parsed.platform)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| (integration test) y |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Load build cache before attempting to lookup file hash
