### PR TITLE
lestarch: adding in BUILD_TESTING setup

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -443,8 +443,20 @@ class Build:
             cmake_args["FPRIME_LIBRARY_LOCATIONS"] = ";".join(
                 cmake_args["FPRIME_LIBRARY_LOCATIONS"]
             )
-
-        cmake_args.update({"CMAKE_BUILD_TYPE": self.build_type.get_cmake_build_type()})
+        # When the new v3 autocoder directory exists, this means we can use the new UT api and preserve the build type
+        v3_autocoder_directory = Path(
+            cmake_args.get("FPRIME_FRAMEWORK_PATH") / "cmake" / "autocoder"
+        )
+        if (
+            v3_autocoder_directory.exists()
+            and self.build_type == BuildType.BUILD_TESTING
+        ):
+            cmake_args.update({"BUILD_TESTING": "ON"})
+            cmake_args.update(
+                {"CMAKE_BUILD_TYPE": cmake_args.get("CMAKE_BUILD_TYPE", "Debug")}
+            )
+        elif self.build_type == BuildType.BUILD_TESTING:
+            cmake_args.update({"CMAKE_BUILD_TYPE": "Testing"})
         return cmake_args
 
     def execute(self, target: Target, context: Path, make_args: dict):

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -14,7 +14,7 @@ from cookiecutter.exceptions import OutputDirExistsException
 from jinja2 import Environment, FileSystemLoader
 
 from fprime.fbuild.builder import Build, Target
-from fprime.fbuild.cmake import CMakeExecutionException, CMakeHandler
+from fprime.fbuild.cmake import CMakeExecutionException
 
 
 def confirm(msg):

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -45,7 +45,7 @@ def run_impl(deployment: Path, path: Path, platform: str, verbose: bool):
     """Run implementation of files one time"""
     target = Target.get_target("impl", set())
     build = Build(target.build_type, deployment, verbose=verbose)
-    build.load(path, platform)
+    build.load(platform)
 
     hpp_files = glob.glob("{}/*.hpp".format(path), recursive=False)
     cpp_files = glob.glob("{}/*.cpp".format(path), recursive=False)
@@ -130,10 +130,12 @@ def suppress_stdout():
 
 
 def regenerate(build: Build):
-    handler = CMakeHandler()
     print("Refreshing cache to include new addition...")
     with suppress_stdout():
-        handler.cmake_refresh_cache(build.get_build_cache())
+        try:
+            build.cmake.cmake_refresh_cache(build.get_build_cache())
+        except CMakeExecutionException:
+            build.cmake.cmake_refresh_cache(build.get_build_cache(), True)
 
 
 def add_unit_tests(deployment, comp_path, platform, verbose):
@@ -144,7 +146,7 @@ def add_unit_tests(deployment, comp_path, platform, verbose):
         test_path.mkdir(parents=True, exist_ok=True)
         target = Target.get_target("impl", {"ut"})
         build = Build(target.build_type, deployment, verbose=verbose)
-        build.load(comp_path, platform)
+        build.load(platform)
         print("Generating unit tests...")
         with suppress_stdout():
             build.execute(target, context=comp_path, make_args={})

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -24,10 +24,11 @@ from fprime.fbuild.builder import (
     Build,
     BuildType,
     GenerateException,
+    NoSuchTargetException,
     Target,
     UnableToDetectDeploymentException,
 )
-from fprime.fbuild.cli import add_fbuild_parsers
+from fprime.fbuild.cli import add_fbuild_parsers, get_target
 from fprime.fpp.cli import add_fpp_parsers
 from fprime.util.cli import add_special_parsers
 
@@ -132,7 +133,15 @@ def utility_entry(args):
 
     try:
         cwd = Path(parsed.path)
-        build_type = BuildType.BUILD_TESTING if parsed.ut else BuildType.BUILD_NORMAL
+
+        try:
+            target = get_target(parsed)
+            build_type = target.build_type
+        except NoSuchTargetException:
+            build_type = (
+                BuildType.BUILD_TESTING if parsed.ut else BuildType.BUILD_NORMAL
+            )
+
         deployment = (
             Path(parsed.deploy)
             if parsed.deploy is not None


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

For new versions of fprime (v3) this uses properly the `CMAKE_BUILD_TYPE` argument.  Users can now set this argument in `fprime-util` as expected, but it is set to DEBUG when a testing run is selected with `--ut`.

This will also set `BUILD_TESTING=ON` with the testing run `--ut` so as to generate the unit tests.

## Changes to check:
- Post v3, `BUILD_TESTING=On` and `CMAKE_BUILD_TYPE=Debug` should be used when build type is BUILD_TESTING.
- Pre v3, `CMAKE_BUILD_TYPE=Testing` is used
- `.load` functions have removed the initial path argument
- rebuild cache function now tries quick, and upon exception, runs full

