### PR TITLE
lestarch: long running message and bug fix with fpp

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -67,6 +67,7 @@ Dxyz
 elif
 endfor
 endif
+endswith
 enum
 excinfo
 exe

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -433,7 +433,7 @@ class CMakeHandler:
                 run_args,
                 write_override=True,
                 environment=environment,
-                print_output=False,
+                print_output=self.verbose,
             )
         else:
             if self.verbose:
@@ -444,7 +444,7 @@ class CMakeHandler:
                 None,
                 top_target=True,
                 full_cache_rebuild=True,
-                print_output=False,
+                print_output=self.verbose,
             )
 
     def _run_cmake(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Several changes:

1. Print message to user when regenerating cache
2. Printing errors for above cache regeneration
3. Outputting full cache regeneration when verbose is set
4. Fix missing FPP files