### PR TITLE
lestarch: fixing setup.py to properly install cookiecutters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,14 @@ to interact with the data coming from the FSW.
     ####
     packages=find_packages("src"),
     package_dir={"": "src"},
+    package_data={
+        "fprime": [
+            "cookiecutter_templates/*",
+            "cookiecutter_templates/*/*",
+            "cookiecutter_templates/*/*/*",
+            "cookiecutter_templates/*/*/*/*",
+        ]
+    },
     ####
     # Classifiers:
     #


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Should fix the setup install of missing cookiecutter templates directory.

To test, pull this branch and run the following:

```
pip uninstall fprime-tools
cd fprime-tools  #With this branch checked out
pip install . # Notice: no -e
cd fprime
fprime-util new --component
```
The above should work, if it does, we'll release v3.0.1 of the tools with the change!