### PR TITLE
Forward CMake exit code

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -496,7 +496,7 @@ class Build:
                 environment=self.settings.get("environment", None),
             )
         except CMakeException as cexc:
-            raise GenerateException(str(cexc)) from cexc
+            raise GenerateException(str(cexc), cexc.exit_code) from cexc
 
     def purge(self):
         """Purge a build cache directory"""
@@ -573,6 +573,10 @@ class Build:
 
 class GenerateException(FprimeException):
     """An exception indicating generate has failed and the user may need to respond"""
+
+    def __init__(self, message, exit_code=1):
+        super().__init__(message)
+        self.exit_code = exit_code
 
 
 class InvalidBuildTypeException(FprimeException):

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -507,6 +507,7 @@ class CMakeHandler:
                 "CMake erred with return code {}".format(proc.returncode),
                 stderr,
                 print_output,
+                ret,
             )
         return stdout, stderr
 
@@ -567,6 +568,10 @@ class CMakeHandler:
 class CMakeException(FprimeException):
     """Error occurred within this CMake package"""
 
+    def __init__(self, message, exit_code=1):
+        super().__init__(message)
+        self.exit_code = exit_code
+
 
 class CMakeInconsistentCacheException(CMakeException):
     """Project CMakeCache.txt is inconsistent with settings.ini file"""
@@ -613,9 +618,9 @@ class CMakeInvalidBuildException(CMakeException):
 class CMakeExecutionException(CMakeException):
     """Pass up a CMake Error as an Exception"""
 
-    def __init__(self, message, stderr, printed):
+    def __init__(self, message, stderr, printed, exit_code=1):
         """The error data should be stored"""
-        super().__init__(message)
+        super().__init__(message, exit_code)
         self.stderr = stderr
         self.need = not printed
 

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -160,6 +160,7 @@ def utility_entry(args):
         )
     except UnableToDetectDeploymentException:
         print(f"[ERROR] Could not detect deployment directory for: {parsed.path}")
+        return 1
     except FprimeException as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
         return 1

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -158,6 +158,7 @@ def utility_entry(args):
             f"[ERROR] {genex}. Partial build cache remains. Run purge to clean-up.",
             file=sys.stderr,
         )
+        return genex.exit_code
     except UnableToDetectDeploymentException:
         print(f"[ERROR] Could not detect deployment directory for: {parsed.path}")
         return 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| CADRE |
|**_Affected Component_**| n/a |
|**_Affected Architectures(s)_**| all |
|**_Related Issue(s)_**| #38 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Return non-zero exit codes from `fprime-util generate`.

## Rationale

Fixes #38 which allows `fprime-util generate` to correctly report when the program fails.

## Testing/Review Recommendations

You can test it against a `CMakeLists.txt` that purposefully fails with a `message(FATAL_ERROR "message")` call. See https://github.jpl.nasa.gov/vnguyen/tmp-fprime-build/blob/dev-non-forwarded-exit-code/fprime-cadre/CMakeLists.txt#L4.

## Future Work

None.
