### PR TITLE
Sort env vars printed before CMake invocation

### DIFF
--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -478,7 +478,7 @@ class CMakeHandler:
         cargs.extend(arguments)
         if self.verbose:
             print("[CMAKE] '{}'".format(" ".join(cargs)))
-            for key, val in cm_environ.items():
+            for key, val in sorted(cm_environ.items(), key=lambda x: x[0]):
                 print("[CMAKE]     {}={}".format(key, val))
 
         # In order to get proper console highlighting while still getting access to the output, we need to create a


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| CADRE |
|**_Affected Component_**| n/a |
|**_Affected Architectures(s)_**| n/a |
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| n/a |

---

Sorts the printed environment variables when invoking CMake to make it easier to interpret.
