### PR TITLE
lestarch: added overridable build cache to fprime-util

### DIFF
--- a/.github/workflows/fprime-tools-ci.yml
+++ b/.github/workflows/fprime-tools-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/fprime-tools-ci.yml
+++ b/.github/workflows/fprime-tools-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,4 +46,4 @@ jobs:
         run: |
           fprime-util generate --build-cache ./special-cache --ut -DFPRIME_ENABLE_AUTOCODER_UTS=OFF
           fprime-util build --build-cache ./special-cache
-          fprime-util hash-to-file 0x6d98b892 --build-cache ./special-cache
+          fprime-util hash-to-file 0x2ed4bda6 --build-cache ./special-cache

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         fprime-version: [[NASA-v1.5.3, 99cef07], [v2.0.0, 521516c], [v3.0.0, 521516c], [devel, 521516c]]
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        fprime-version: [[NASA-v1.5.3, 99cef07], [v2.0.0, 521516c] , [devel, 521516c]]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        fprime-version: [[NASA-v1.5.3, 99cef07], [v2.0.0, 521516c], [v3.0.0, 521516c], [devel, 521516c]]
 
     steps:
       - uses: actions/checkout@v2
@@ -41,3 +41,9 @@ jobs:
           fprime-util generate
           fprime-util build
           fprime-util hash-to-file 0x72ad3277
+      - name: Test special generation on Ref
+        working-directory: fprime/Ref
+        run: |
+          fprime-util generate --build-cache ./special-cache -DBUILD_TESTING=ON -DFPRIME_ENABLE_AUTOCODER_UTS=OFF
+          fprime-util build --build-cache ./special-cache
+          fprime-util hash-to-file 0x6d98b892 --build-cache ./special-cache

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Test special generation on Ref
         working-directory: fprime/Ref
         run: |
-          fprime-util generate --build-cache ./special-cache -DBUILD_TESTING=ON -DFPRIME_ENABLE_AUTOCODER_UTS=OFF
+          fprime-util generate --build-cache ./special-cache --ut -DFPRIME_ENABLE_AUTOCODER_UTS=OFF
           fprime-util build --build-cache ./special-cache
           fprime-util hash-to-file 0x6d98b892 --build-cache ./special-cache

--- a/src/fprime/common/models/serialize/numerical_types.py
+++ b/src/fprime/common/models/serialize/numerical_types.py
@@ -44,6 +44,7 @@ class NumericalType(ValueType, abc.ABC):
     @abc.abstractmethod
     def get_serialize_format():
         """Gets the format serialization string such that the class can be serialized via struct"""
+        raise NotImplementedError("get_serialize_format")
 
     def serialize(self):
         """Serializes this type using struct and the val property"""

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -48,6 +48,8 @@ class BuildType(Enum):
             return "Testing"
         if self == BuildType.BUILD_FPP_LOCS:
             return "Release"
+        if self == BuildType.BUILD_CUSTOM:
+            return "Custom"
         raise InvalidBuildTypeException(
             "{} is not a supported build type".format(self.name)
         )
@@ -311,7 +313,7 @@ class Build:
             )
         with open(hashes_file) as file_handle:
             lines = filter(
-                lambda line: "{:x}".format(hash_value) in line, file_handle.readlines()
+                lambda line: hash_value == int(line.split(" ")[-1], 0), file_handle.readlines()
             )
         return list(lines)
 
@@ -369,6 +371,7 @@ class Build:
             "local_targets": local_targets,
             "global_targets": global_targets,
             "auto_location": auto_location,
+            "build_dir": self.build_dir
         }
 
     def find_toolchain(self):

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -313,7 +313,8 @@ class Build:
             )
         with open(hashes_file) as file_handle:
             lines = filter(
-                lambda line: hash_value == int(line.split(" ")[-1], 0), file_handle.readlines()
+                lambda line: hash_value == int(line.split(" ")[-1], 0),
+                file_handle.readlines(),
             )
         return list(lines)
 
@@ -371,7 +372,7 @@ class Build:
             "local_targets": local_targets,
             "global_targets": global_targets,
             "auto_location": auto_location,
-            "build_dir": self.build_dir
+            "build_dir": self.build_dir,
         }
 
     def find_toolchain(self):

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -8,7 +8,7 @@ target operations.
 import argparse
 from pathlib import Path
 from typing import Dict, List, Tuple, Callable
-from fprime.fbuild.builder import Target, BuildType, Build, InvalidBuildCacheException
+from fprime.fbuild.builder import Target, BuildType, Build
 from fprime.fbuild.interaction import confirm
 
 

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -45,7 +45,7 @@ def run_fbuild_cli(
         make_args: arguments to the make system
     """
     if parsed.command == "generate":
-        build.invent(parsed.platform)
+        build.invent(parsed.platform, build_dir=parsed.build_cache)
         toolchain = build.find_toolchain()
         print(f"[INFO] Generating build directory at: {build.build_dir}")
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
@@ -53,28 +53,25 @@ def run_fbuild_cli(
             cmake_args.update({"CMAKE_TOOLCHAIN_FILE": toolchain})
         build.generate(cmake_args)
     elif parsed.command == "purge":
-        for build_type in BuildType.get_public_types():
-            purge_build = Build(build_type, build.deployment, verbose=parsed.verbose)
-            try:
-                purge_build.load(parsed.platform)
-            except InvalidBuildCacheException:
-                continue
-            # Always attempt to remove the install directory
-            finally:
-                install_dir = purge_build.install_dest_exists()
-                if install_dir:
-                    print(
-                        f"[INFO] {parsed.command.title()} install directory at: {install_dir}"
-                    )
-                    if parsed.force or confirm(
-                        "Purge installation directory (yes/no)?"
-                    ):
-                        purge_build.purge_install()
+        for purge_build in Build.get_build_list(build, parsed.build_cache):
             print(
                 f"[INFO] {parsed.command.title()} build directory at: {purge_build.build_dir}"
             )
             if parsed.force or confirm("Purge this directory (yes/no)?"):
                 purge_build.purge()
+            install_dir = purge_build.install_dest_exists()
+            if (
+                purge_build.build_type != BuildType.BUILD_CUSTOM
+                and install_dir
+                and install_dir.exists()
+            ):
+                print(
+                    f"[INFO] {parsed.command.title()} install directory at: {install_dir}"
+                )
+                if parsed.force or confirm(
+                    f"Purge installation directory at {install_dir} (yes/no)?"
+                ):
+                    purge_build.purge_install()
     else:
         target = get_target(parsed)
         build.execute(target, context=Path(parsed.path), make_args=make_args)

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -56,6 +56,9 @@ def validate(parsed, unknown):
     elif parsed.command in Target.get_all_targets():
         parsed.settings = None  # Force to load from cache if possible
         make_args.update({"--jobs": (1 if parsed.jobs <= 0 else parsed.jobs)})
+    parsed.build_cache = (
+        None if parsed.build_cache is None else Path(parsed.build_cache)
+    )
     return cmake_args, make_args
 
 
@@ -87,6 +90,12 @@ def parse_args(args):
         "--path",
         default=os.getcwd(),
         help="F prime directory to operate on. Default: cwd, %(default)s.",
+    )
+    common_parser.add_argument(
+        "--build-cache",
+        dest="build_cache",
+        default=None,
+        help="Overrides the build cache with a specific directory",
     )
     common_parser.add_argument(
         "-v",
@@ -151,7 +160,7 @@ def utility_entry(args):
 
         # When not handling generate/purge we need a valid build cache and should load it
         if parsed.command not in ["generate", "purge"]:
-            build.load(parsed.platform)
+            build.load(parsed.platform, parsed.build_cache)
         runners[parsed.command](build, parsed, cmake_args, make_args)
     except GenerateException as genex:
         print(

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -10,7 +10,7 @@ import sys
 
 from pathlib import Path
 from typing import Dict, Callable
-from fprime.fbuild.builder import Build, BuildType, InvalidBuildCacheException
+from fprime.fbuild.builder import Build, InvalidBuildCacheException
 from fprime.fbuild.interaction import new_component, new_port
 
 

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -28,22 +28,12 @@ def print_info(
         _: unused cmake arguments
         __: unused make arguments
     """
-    build_types = BuildType.get_public_types()
-
     # Roll up targets for more concise display
     build_infos = {}
     local_generic_targets = set()
     global_generic_targets = set()
     # Loop through available builds and harvest targets
-    for build_type in build_types:
-        build = Build(base.build_type, base.deployment, verbose=parsed.verbose)
-        try:
-            build.load(parsed.platform)
-        except InvalidBuildCacheException:
-            print(
-                f"[WARNING] No results for build type '{build_type.get_cmake_build_type()}', missing build cache."
-            )
-            continue
+    for build in Build.get_build_list(base, parsed.build_cache):
         build_info = build.get_build_info(Path(parsed.path))
         # Target list
         local_targets = {
@@ -59,7 +49,7 @@ def print_info(
         )
         local_generic_targets = local_generic_targets.union(local_targets)
         global_generic_targets = global_generic_targets.union(global_targets)
-        build_infos[build_type] = build_artifacts
+        build_infos[build.build_type] = build_artifacts
 
     # Print out directory and deployment target sections
     print(f"[INFO] Fprime build information:")

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -45,7 +45,8 @@ def print_info(
         build_artifacts = (
             build_info.get("auto_location")
             if build_info.get("auto_location") is not None
-            else "N/A", build_info.get("build_dir", "Unknown")
+            else "N/A",
+            build_info.get("build_dir", "Unknown"),
         )
         local_generic_targets = local_generic_targets.union(local_targets)
         global_generic_targets = global_generic_targets.union(global_targets)
@@ -59,7 +60,10 @@ def print_info(
 
     # Artifact locations come afterwards
     print("  ----------------------------------------------------------")
-    for build_type, (build_artifact_location, global_build_cache) in build_infos.items():
+    for build_type, (
+        build_artifact_location,
+        global_build_cache,
+    ) in build_infos.items():
         print(
             f"    {build_type.get_cmake_build_type()} build cache module directory: {build_artifact_location}"
         )

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -45,7 +45,7 @@ def print_info(
         build_artifacts = (
             build_info.get("auto_location")
             if build_info.get("auto_location") is not None
-            else "N/A"
+            else "N/A", build_info.get("build_dir", "Unknown")
         )
         local_generic_targets = local_generic_targets.union(local_targets)
         global_generic_targets = global_generic_targets.union(global_targets)
@@ -59,9 +59,12 @@ def print_info(
 
     # Artifact locations come afterwards
     print("  ----------------------------------------------------------")
-    for build_type, build_artifact_location in build_infos.items():
+    for build_type, (build_artifact_location, global_build_cache) in build_infos.items():
         print(
-            f"    {build_type.get_cmake_build_type()} build cache: {build_artifact_location}"
+            f"    {build_type.get_cmake_build_type()} build cache module directory: {build_artifact_location}"
+        )
+        print(
+            f"    {build_type.get_cmake_build_type()} build cache: {global_build_cache}"
         )
     print()
 
@@ -80,7 +83,7 @@ def hash_to_file(
     lines = build.find_hashed_file(parsed.hash)
     if not lines:
         raise InvalidBuildCacheException(
-            "No hashes.txt found. Do you need '--ut' for a unittest run?"
+            f"Hash 0x{parsed.hash:x} not found. Do you need '--ut' for a unittest run?"
         )
     print("[INFO] File(s) associated with hash 0x{:x}".format(parsed.hash))
     for line in lines:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds in the ability to add a specific build cache using the `--build-cache` flag.  This way any number of configurations can be maintained by hand.

e.g.
```
fprime-util generate --build-cache my_fancy_build -DSOME_SETTING=ON -DSOME_OTHER_SETTING=OFF
```

@vietjtnguyen does this meet your recommendation?  Rather than managing suffixs I figured I'd put in the full explicit override so the user can specify any build cache, even one made by hand.
