### PR TITLE
lestarch: debug build type properly capatalized for unit test builds

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -459,7 +459,7 @@ class Build:
         ):
             cmake_args.update({"BUILD_TESTING": "ON"})
             cmake_args.update(
-                {"CMAKE_BUILD_TYPE": cmake_args.get("CMAKE_BUILD_TYPE", "Debug")}
+                {"CMAKE_BUILD_TYPE": cmake_args.get("CMAKE_BUILD_TYPE", "DEBUG")}
             )
         elif self.build_type == BuildType.BUILD_TESTING:
             cmake_args.update({"CMAKE_BUILD_TYPE": "Testing"})


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

CMAKE_BUILD_TYPE works as advertised.  This was the only correction.