### PR TITLE
add MarkupSafe==2.0.1 to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ to interact with the data coming from the FSW.
     install_requires=[
         "lxml==4.6.3",
         "Markdown==3.3.4",
-        "MarkupSafe==2.0.1",
+        "MarkupSafe<2.0.0",
         "pexpect==4.8.0",
         "pytest==6.2.4",
         "Cheetah3==3.2.6",

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ to interact with the data coming from the FSW.
     install_requires=[
         "lxml==4.6.3",
         "Markdown==3.3.4",
+        "MarkupSafe==2.0.1",
         "pexpect==4.8.0",
         "pytest==6.2.4",
         "Cheetah3==3.2.6",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

add `"MarkupSafe==2.0.1"` to `install_requires` in setup.py

## Rationale

Fixes #48 

## Testing/Review Recommendations

- `pip install fprime-tools`
- Check MarkupSafe version by running `pip freeze | grep MarkupSafe`
- If MarkupSafe version is 2.1.1, `fprime-util --help` may throw an error
- Clone & cd into fprime-tools repo and checkout commit https://github.com/fprime-community/fprime-tools/commit/23c25be0f20de327dae12d67c82244faba41040c
- Reinstall fprime-tools with `python setup.py install`
- Rerun `fprime-util --help`
