### PR TITLE
Codebase formatting with ``f-string``

### DIFF
--- a/src/fprime/common/models/serialize/enum_type.py
+++ b/src/fprime/common/models/serialize/enum_type.py
@@ -87,9 +87,7 @@ class EnumType(ValueType):
             int_val = struct.unpack_from(">i", data, offset)[0]
         except:
             raise DeserializeException(
-                "Could not deserialize enum value. Needed: {} bytes Found: {}".format(
-                    self.getSize(), len(data[offset:])
-                )
+                f"Could not deserialize enum value. Needed: {self.getSize()} bytes Found: {len(data[offset:])}"
             )
         for key, val in self.enum_dict().items():
             if int_val == val:

--- a/src/fprime/common/models/serialize/numerical_types.py
+++ b/src/fprime/common/models/serialize/numerical_types.py
@@ -30,9 +30,7 @@ class NumericalType(ValueType, abc.ABC):
         match = BITS_RE.match(cls.__name__)
         assert (
             match
-        ), "Type {} does not follow format I#Type U#Type nor F#Type required of numerical types".format(
-            cls
-        )
+        ), f"Type {cls} does not follow format I#Type U#Type nor F#Type required of numerical types"
         return int(match.group(1))
 
     @classmethod

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -64,9 +64,7 @@ class StringType(type_base.ValueType):
             # Deal with not enough data left in the buffer
             if len(data[offset + 2 :]) < val_size:
                 raise DeserializeException(
-                    "Not enough data to deserialize string data. Needed: {} Left: {}".format(
-                        val_size, len(data[offset + 2 :])
-                    )
+                    f"Not enough data to deserialize string data. Needed: {val_size} Left: {len(data[offset + 2 :])}"
                 )
             # Deal with a string that is larger than max string
             elif self.__max_string_len is not None and val_size > self.__max_string_len:

--- a/src/fprime/common/models/serialize/type_exceptions.py
+++ b/src/fprime/common/models/serialize/type_exceptions.py
@@ -25,32 +25,28 @@ class AbstractMethodException(TypeException):
     """Not implemented exception under another name"""
 
     def __init__(self, val):
-        super().__init__("%s must be implemented since it is abstract!" % str(val))
+        super().__init__(f"{str(val)} must be implemented since it is abstract!")
 
 
 class TypeRangeException(TypeException):
     """Value is out of range"""
 
     def __init__(self, val):
-        super().__init__("Value %s out of range!" % str(val))
+        super().__init__(f"Value {str(val)} out of range!")
 
 
 class StringSizeException(TypeException):
     """String size is to large for defined type"""
 
     def __init__(self, size, max_size):
-        super().__init__(
-            "String size {} is greater than {}!".format(str(size), str(max_size))
-        )
+        super().__init__(f"String size {str(size)} is greater than {str(max_size)}!")
 
 
 class TypeMismatchException(TypeException):
     """Wrong type found exception"""
 
     def __init__(self, expected_type, actual_type):
-        super().__init__(
-            "Type {} expected, type {} found!".format(expected_type, actual_type)
-        )
+        super().__init__(f"Type {expected_type} expected, type {actual_type} found!")
 
 
 class ArrayLengthException(TypeException):
@@ -58,8 +54,7 @@ class ArrayLengthException(TypeException):
 
     def __init__(self, arr_type, expected_len, actual_len):
         super().__init__(
-            "Array type %s is of length %s, actual length %s found!"
-            % (arr_type, expected_len, actual_len)
+            f"Array type {arr_type} is of length {expected_len}, actual length {actual_len} found!"
         )
 
 
@@ -67,9 +62,7 @@ class EnumMismatchException(TypeException):
     """Enum member not defined"""
 
     def __init__(self, enum, bad_member):
-        super().__init__(
-            "Invalid enum member {} set in {} enum!".format(bad_member, enum)
-        )
+        super().__init__(f"Invalid enum member {bad_member} set in {enum} enum!")
 
 
 class DeserializeException(TypeException):
@@ -82,14 +75,14 @@ class ArgNotFoundException(TypeException):
     """Argument not found exception"""
 
     def __init__(self, message):
-        super().__init__("Arg %s not found!" % message)
+        super().__init__(f"Arg {message} not found!")
 
 
 class NotInitializedException(TypeException):
     """Did not initialize types"""
 
     def __init__(self, message):
-        super().__init__("Instance %s not initialized!" % message)
+        super().__init__(f"Instance {message} not initialized!")
 
 
 class NotOverriddenException(TypeException):
@@ -97,7 +90,7 @@ class NotOverriddenException(TypeException):
 
     def __init__(self, message):
         super().__init__(
-            "Required base class method not overwritten in type %s!" % message
+            f"Required base class method not overwritten in type {message}!"
         )
 
 

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -36,9 +36,7 @@ class BuildType(Enum):
             return ""
         if self == BuildType.BUILD_TESTING:
             return "-ut"
-        raise InvalidBuildTypeException(
-            "{} is not a supported build type".format(self.name)
-        )
+        raise InvalidBuildTypeException(f"{self.name} is not a supported build type")
 
     def get_cmake_build_type(self):
         """Get the suffix of a directory supporting this build"""
@@ -50,9 +48,7 @@ class BuildType(Enum):
             return "Release"
         if self == BuildType.BUILD_CUSTOM:
             return "Custom"
-        raise InvalidBuildTypeException(
-            "{} is not a supported build type".format(self.name)
-        )
+        raise InvalidBuildTypeException(f"{self.name} is not a supported build type")
 
     @staticmethod
     def get_public_types() -> List["BuildType"]:
@@ -114,9 +110,9 @@ class Target(ABC):
         Returns:
             string of format "mnemonic --flag1 --flag2 ..."
         """
-        flag_string = " ".join(["--{}".format(flag) for flag in flags])
-        flag_string = "" if flag_string == "" else " " + flag_string
-        return "{}{}".format(mnemonic, flag_string)
+        flag_string = " ".join([f"--{flag}" for flag in flags])
+        flag_string = f" {flag_string}" if flag_string else ""
+        return f"{mnemonic}{flag_string}"
 
     @classmethod
     def get_all_possible_flags(cls) -> Set[str]:
@@ -158,7 +154,7 @@ class Target(ABC):
                 matching.append(target)
         if not matching:
             raise NoSuchTargetException(
-                "Could not find target '{}'".format(cls.config_string(mnemonic, flags))
+                f"Could not find target '{cls.config_string(mnemonic, flags)}'"
             )
         assert len(matching) == 1, "Conflicting targets specified in code"
         return matching[0]
@@ -244,9 +240,7 @@ class Build:
         """
         self.__setup_default(platform, build_dir)
         if self.build_dir.exists():
-            raise InvalidBuildCacheException(
-                "{} already exists.".format(self.build_dir)
-            )
+            raise InvalidBuildCacheException(f"{self.build_dir} already exists.")
 
     def load(self, platform: str = None, build_dir: Path = None):
         """Load an existing build cache
@@ -269,9 +263,7 @@ class Build:
         ):
             gen_args = " --ut" if self.build_type == BuildType.BUILD_TESTING else ""
             raise InvalidBuildCacheException(
-                "'{}' is not a valid build cache. Generate this build cache with 'fprime-util generate{}'".format(
-                    self.build_dir, gen_args
-                )
+                f"'{self.build_dir}' is not a valid build cache. Generate this build cache with 'fprime-util generate{gen_args}'"
             )
 
     def get_settings(
@@ -309,7 +301,7 @@ class Build:
         hashes_file = self.build_dir / "hashes.txt"
         if not hashes_file.exists():
             raise InvalidBuildCacheException(
-                "Failed to find {}, was the build generated.".format(hashes_file)
+                f"Failed to find {hashes_file}, was the build generated."
             )
         with open(hashes_file) as file_handle:
             lines = filter(
@@ -397,7 +389,7 @@ class Build:
             return None
         # Otherwise, find locations of toolchain files using the specified locations from settings.
         toolchains_paths = [
-            os.path.join(loc, "cmake", "toolchain", self.platform + ".cmake")
+            os.path.join(loc, "cmake", "toolchain", f'{self.platform}.cmake')
             for loc in toolchain_locations
             if loc is not None
         ]
@@ -411,15 +403,11 @@ class Build:
         )
         if not toolchains:
             raise NoSuchToolchainException(
-                "Could not find toolchain file for {} at any of: {}".format(
-                    self.platform, " ".join(toolchains_paths)
-                )
+                f'Could not find toolchain file for {self.platform} at any of: {" ".join(toolchains_paths)}'
             )
         if len(toolchains) > 1:
             raise AmbiguousToolchainException(
-                "Found conflicting toolchain files for {} at: {}".format(
-                    self.platform, " ".join(toolchains)
-                )
+                f'Found conflicting toolchain files for {self.platform} at: {" ".join(toolchains)}'
             )
         return toolchains[0]
 

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -107,7 +107,7 @@ def add_target_parser(
             target.mnemonic,
             parents=[common],
             add_help=False,
-            help="{} in the specified directory".format(target.desc),
+            help=f"{target.desc} in the specified directory",
         )
         # --ut flag also exists at the global parsers, skip adding it
         existing[target.mnemonic] = (parser, ["ut"])
@@ -123,7 +123,7 @@ def add_target_parser(
     new_flags = [flag for flag in target.flags if flag not in flags]
     for flag in new_flags:
         parser.add_argument(
-            "--{}".format(flag), action="store_true", default=False, help=target.desc
+            f"--{flag}", action="store_true", default=False, help=target.desc
         )
     flags.extend(new_flags)
     return target.mnemonic

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -95,7 +95,7 @@ class CMakeHandler:
 
         make_args = {} if make_args is None else make_args
         fleshed_args = ["--"] + list(
-            map(lambda key: "{}={}".format(key, make_args[key]), make_args.keys())
+            map(lambda key: f"{key}={make_args[key]}", make_args.keys())
         )
 
         if target != "" and top_target:
@@ -106,7 +106,7 @@ class CMakeHandler:
                 module
                 if target == ""
                 else (
-                    "{}_{}".format(module, target).lstrip("_")
+                    f"{module}_{target}".lstrip("_")
                     if not top_target
                     else target
                 )
@@ -399,7 +399,7 @@ class CMakeHandler:
             )
             if not project_lines:
                 raise CMakeProjectException(
-                    source_dir, "No 'project()' calls in {}".format(cmake_file)
+                    source_dir, f"No 'project()' calls in {cmake_file}"
                 )
 
     @staticmethod
@@ -477,9 +477,9 @@ class CMakeHandler:
             cargs.append("-N")
         cargs.extend(arguments)
         if self.verbose:
-            print("[CMAKE] '{}'".format(" ".join(cargs)))
+            print(f"""[CMAKE] '{" ".join(cargs)}'""")
             for key, val in sorted(cm_environ.items(), key=lambda x: x[0]):
-                print("[CMAKE]     {}={}".format(key, val))
+                print(f"[CMAKE]     {key}={val}")
 
         # In order to get proper console highlighting while still getting access to the output, we need to create a
         # pseudo-terminal. This will allow the proc to write to one side, and our select below to read from the other
@@ -504,7 +504,7 @@ class CMakeHandler:
         # needed. Thus we do not just exit.
         if ret != 0:
             raise CMakeExecutionException(
-                "CMake erred with return code {}".format(proc.returncode),
+                f"CMake erred with return code {proc.returncode}",
                 stderr,
                 print_output,
                 ret,
@@ -579,9 +579,7 @@ class CMakeInconsistentCacheException(CMakeException):
     def __init__(self, key, expected, actual):
         """Force an appropriate message"""
         super().__init__(
-            "Expected CMake variable {} to be set to '{}', was actually set to '{}'. This is usually caused by updating the settings.ini file without purging and regenerating the accompanying build cache.".format(
-                key, expected, actual
-            )
+            f"Expected CMake variable {key} to be set to '{expected}', was actually set to '{actual}'. This is usually caused by updating the settings.ini file without purging and regenerating the accompanying build cache."
         )
 
 
@@ -590,7 +588,7 @@ class CMakeOrphanException(CMakeException):
 
     def __init__(self, file_dir):
         """Force an appropriate message"""
-        super().__init__("{} is outside the F prime project".format(file_dir))
+        super().__init__(f"{file_dir} is outside the F prime project")
 
 
 class CMakeProjectException(CMakeException):
@@ -598,9 +596,7 @@ class CMakeProjectException(CMakeException):
 
     def __init__(self, project_dir, error):
         """Force an appropriate message"""
-        super().__init__(
-            "{} is an invalid F prime deployment. {}".format(project_dir, error)
-        )
+        super().__init__(f"{project_dir} is an invalid F prime deployment. {error}")
 
 
 class CMakeInvalidBuildException(CMakeException):
@@ -609,9 +605,7 @@ class CMakeInvalidBuildException(CMakeException):
     def __init__(self, build_dir):
         """Force an appropriate message"""
         super().__init__(
-            "{} is not a CMake build directory. Please setup using 'fprime-util generate'".format(
-                build_dir
-            )
+            f"{build_dir} is not a CMake build directory. Please setup using 'fprime-util generate'"
         )
 
 
@@ -644,4 +638,4 @@ class CMakeNoSuchTargetException(CMakeException):
 
     def __init__(self, build_dir, target):
         """Better messaging for this exception"""
-        super().__init__("{} does not support target {}".format(build_dir, target))
+        super().__init__(f"{build_dir} does not support target {target}")

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -26,7 +26,7 @@ def confirm(msg):
             return True
         if confirm_input.lower() in ["n", "no"]:
             return False
-        print("{} is invalid.  Please use 'yes' or 'no'".format(confirm_input))
+        print(f"{confirm_input} is invalid.  Please use 'yes' or 'no'")
 
 
 def replace_contents(filename, what, replacement, count=1):
@@ -47,8 +47,8 @@ def run_impl(deployment: Path, path: Path, platform: str, verbose: bool):
     build = Build(target.build_type, deployment, verbose=verbose)
     build.load(platform)
 
-    hpp_files = glob.glob("{}/*.hpp".format(path), recursive=False)
-    cpp_files = glob.glob("{}/*.cpp".format(path), recursive=False)
+    hpp_files = glob.glob(f"{path}/*.hpp", recursive=False)
+    cpp_files = glob.glob(f"{path}/*.cpp", recursive=False)
     cpp_files.sort(key=len)
 
     # Check destinations
@@ -63,15 +63,15 @@ def run_impl(deployment: Path, path: Path, platform: str, verbose: bool):
     cpp_dest = common[0] if common else cpp_files[0]
 
     if not confirm(
-        "Generate implementations and merge into {} and {}?".format(hpp_dest, cpp_dest)
+        f"Generate implementations and merge into {hpp_dest} and {cpp_dest}?"
     ):
         return False
     print("Generating implementation files and merging...")
     with suppress_stdout():
         build.execute(target, context=path, make_args={})
 
-    hpp_files_template = glob.glob("{}/*.hpp-template".format(path), recursive=False)
-    cpp_files_template = glob.glob("{}/*.cpp-template".format(path), recursive=False)
+    hpp_files_template = glob.glob(f"{path}/*.hpp-template", recursive=False)
+    cpp_files_template = glob.glob(f"{path}/*.cpp-template", recursive=False)
 
     if not hpp_files_template or not cpp_files_template:
         print("[WARNING] Failed to find generated .cpp-template or .hpp-template files")
@@ -96,7 +96,7 @@ def run_impl(deployment: Path, path: Path, platform: str, verbose: bool):
 
 def add_to_cmake(list_file: Path, comp_path: Path):
     """Adds new component or port to CMakeLists.txt"""
-    print("[INFO] Found CMakeLists.txt at '{}'".format(list_file))
+    print(f"[INFO] Found CMakeLists.txt at '{list_file}'")
     with open(list_file, "r") as f:
         lines = f.readlines()
 
@@ -108,7 +108,7 @@ def add_to_cmake(list_file: Path, comp_path: Path):
         return True
 
     if not confirm(
-        "Add component {} to {} {}".format(comp_path, list_file, "at end of file?")
+        f"Add component {comp_path} to {list_file} at end of file?"
     ):
         return False
 
@@ -188,7 +188,7 @@ def add_unit_tests(deployment, comp_path, platform, verbose):
 
 def add_port_to_cmake(list_file: Path, comp_path: Path):
     """Adds new port to CMakeLists.txt in port directory"""
-    print("[INFO] Found CMakeLists.txt at '{}'".format(list_file))
+    print(f"[INFO] Found CMakeLists.txt at '{list_file}'")
     with open(list_file, "r") as file_handle:
         lines = file_handle.readlines()
     index = 0
@@ -198,7 +198,7 @@ def add_port_to_cmake(list_file: Path, comp_path: Path):
     while "CMAKE_CURRENT_LIST_DIR" in lines[index]:
         index += 1
     if not confirm(
-        "Add port {} to {} {}?".format(comp_path, list_file, "ports in CMakeLists.txt")
+        f"Add port {comp_path} to {list_file} ports in CMakeLists.txt?"
     ):
         return False
 
@@ -253,7 +253,7 @@ def new_component(deployment: Path, platform: str, verbose: bool, build: Build):
             and build.get_settings("component_cookiecutter", None) != "default"
         ):
             source = build.get_settings("component_cookiecutter", None)
-            print("[INFO] Cookiecutter source: {}".format(source))
+            print(f"[INFO] Cookiecutter source: {source}")
         else:
             source = (
                 os.path.dirname(__file__)
@@ -266,9 +266,7 @@ def new_component(deployment: Path, platform: str, verbose: bool, build: Build):
         ).resolve()
         if proj_root is None:
             print(
-                "[INFO] Created component directory without adding to build system nor generating implementation {}".format(
-                    final_component_dir
-                )
+                f"[INFO] Created component directory without adding to build system nor generating implementation {final_component_dir}"
             )
             return 0
         # Attempt to register to CMakeLists.txt
@@ -280,9 +278,7 @@ def new_component(deployment: Path, platform: str, verbose: bool, build: Build):
             cmake_lists_file, final_component_dir.relative_to(cmake_lists_file.parent)
         ):
             print(
-                "[INFO] Could not register {} with build system. Please add it and generate implementations manually.".format(
-                    final_component_dir
-                )
+                f"[INFO] Could not register {final_component_dir} with build system. Please add it and generate implementations manually."
             )
             return 0
         regenerate(build)
@@ -303,17 +299,15 @@ def new_component(deployment: Path, platform: str, verbose: bool, build: Build):
 
         add_unit_tests(deployment, final_component_dir, platform, verbose)
         print(
-            "[INFO] Next run `fprime-util build{}` in {}".format(
-                "" if platform is None else " " + platform, final_component_dir
-            )
+            f'[INFO] Next run `fprime-util build{"" if platform is None else f" {platform}"}` in {final_component_dir}'
         )
         return 0
     except OutputDirExistsException as out_directory_error:
-        print("{}".format(out_directory_error), file=sys.stderr)
+        print(f"{out_directory_error}", file=sys.stderr)
     except CMakeExecutionException as exc:
-        print("[ERROR] Failed to create component. {}".format(exc), file=sys.stderr)
+        print(f"[ERROR] Failed to create component. {exc}", file=sys.stderr)
     except OSError as ose:
-        print("[ERROR] {}".format(ose))
+        print(f"[ERROR] {ose}")
     return 1
 
 
@@ -373,12 +367,12 @@ def get_port_input(namespace):
     }
     args_done = False
     arg_list = []
-    port_name = get_valid_input("Port Name [{}]: ".format(defaults["port_name"]))
+    port_name = get_valid_input(f'Port Name [{defaults["port_name"]}]: ')
     short_description = input(
-        "Short Description [{}]: ".format(defaults["short_description"])
+        f'Short Description [{defaults["short_description"]}]: '
     )
-    dir_name = get_valid_input("Directory Name [{}]: ".format(defaults["dir_name"]))
-    namespace = get_valid_input("Port Namespace [{}]: ".format(defaults["namespace"]))
+    dir_name = get_valid_input(f'Directory Name [{defaults["dir_name"]}]: ')
+    namespace = get_valid_input(f'Port Namespace [{defaults["namespace"]}]: ')
     while not args_done:
         if arg_list == []:
             add_arg = confirm("Would you like to add an argument?: ")
@@ -472,9 +466,7 @@ def new_port(deployment: Path, build: Build):
             (Path(context["dir_name"]).resolve()).relative_to(cmake_lists_file.parent),
         ):
             print(
-                "[INFO] Could not register {} with build system. Please add it and generate implementations manually.".format(
-                    Path(context["dir_name"]).resolve()
-                )
+                f'[INFO] Could not register {Path(context["dir_name"]).resolve()} with build system. Please add it and generate implementations manually.'
             )
             return 0
         regenerate(build)
@@ -495,9 +487,9 @@ def new_port(deployment: Path, build: Build):
         )
         return 0
     except OutputDirExistsException as out_directory_error:
-        print("{}".format(out_directory_error), file=sys.stderr)
+        print(f"{out_directory_error}", file=sys.stderr)
     except CMakeExecutionException as exc:
-        print("[ERROR] Failed to create port. {}".format(exc), file=sys.stderr)
+        print(f"[ERROR] Failed to create port. {exc}", file=sys.stderr)
     except OSError as ose:
-        print("[ERROR] {}".format(ose))
+        print(f"[ERROR] {ose}")
     return 1

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -59,9 +59,7 @@ class IniSettings:
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):
                 raise FprimeSettingsException(
-                    "Nonexistent path '{}' found in section '{}' option '{}' of file '{}'".format(
-                        path, section, key, ini_file
-                    )
+                    f"Nonexistent path '{path}' found in section '{section}' option '{key}' of file '{ini_file}'"
                 )
             expanded.append(full_path)
         return expanded
@@ -84,7 +82,7 @@ class IniSettings:
 
         # Check file existence if specified
         if not os.path.exists(settings_file):
-            print("[WARNING] Failed to find settings file: {}".format(settings_file))
+            print(f"[WARNING] Failed to find settings file: {settings_file}")
             fprime_location = IniSettings.find_fprime(settings_file.parent)
             return {"framework_path": fprime_location, "install_dest": dfl_install_dest}
         confparse = configparser.ConfigParser()

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -129,7 +129,7 @@ def parse_args(args):
         parser.print_help()
         sys.exit(1)
     elif bad:
-        print("[ERROR] Unknown arguments: {}".format(", ".join(bad)))
+        print(f'[ERROR] Unknown arguments: {", ".join(bad)}')
         parser.print_help()
         sys.exit(1)
     cmake_args, make_args = validate(parsed, unknown)

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -37,10 +37,10 @@ def print_info(
         build_info = build.get_build_info(Path(parsed.path))
         # Target list
         local_targets = {
-            "'{}'".format(target) for target in build_info.get("local_targets", [])
+            f"'{target}'" for target in build_info.get("local_targets", [])
         }
         global_targets = {
-            "'{}'".format(target) for target in build_info.get("global_targets", [])
+            f"'{target}'" for target in build_info.get("global_targets", [])
         }
         build_artifacts = (
             build_info.get("auto_location")
@@ -53,7 +53,7 @@ def print_info(
         build_infos[build.build_type] = build_artifacts
 
     # Print out directory and deployment target sections
-    print(f"[INFO] Fprime build information:")
+    print("[INFO] Fprime build information:")
     print(f"    Available directory targets: {' '.join(local_generic_targets)}")
     print()
     print(f"    Available deployment targets: {' '.join(global_generic_targets)}")

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -34,9 +34,7 @@ def get_data_dir():
     if type(get_cmake_builder()) == fprime.fbuild.cmake.CMakeHandler:
         return os.path.join(os.path.dirname(__file__), "cmake-data")
     raise Exception(
-        "Test data directory not setup for {} builder class".format(
-            type(get_cmake_builder())
-        )
+        f"Test data directory not setup for {type(get_cmake_builder())} builder class"
     )
 
 

--- a/test/fprime/fbuild/test_settings.py
+++ b/test/fprime/fbuild/test_settings.py
@@ -95,6 +95,6 @@ def test_settings():
     for case in test_cases:
         fp = full_path("settings-data/" + case["file"])
         results = IniSettings.load(fp)
-        assert case["expected"] == results, "{}: Expected {}, got {}".format(
-            fp, case["expected"], results
-        )
+        assert (
+            case["expected"] == results
+        ), f'{fp}: Expected {case["expected"]}, got {results}'


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---

## Change Description

- Replace calls to ``string.format()`` with ``f-strings`` [ref](https://docs.sourcery.ai/refactorings/use-fstring-for-formatting/)
- Replace the use of the ``%`` string interpolation operator with ``f-strings`` (only ``%s`` operator) [ref](https://docs.sourcery.ai/refactorings/replace-interpolation-with-fstring/)

## Rationale

According to the [Python documentation](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting), using the ``%`` operator to format strings can lead to "a variety of quirks that lead to a number of common errors."

[PEP 498](https://peps.python.org/pep-0498/) added F-strings to Python in version 3.6. F-strings are a versatile and powerful method of string formatting. Because the code looks more like the output, they make it shorter and more readable.

## Testing/Review Recommendations



## Future Work

Deals with operators other than ``%s`` like ``%d``.