### PR TITLE
lestarch: fixing formatting broken by #50

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -389,7 +389,7 @@ class Build:
             return None
         # Otherwise, find locations of toolchain files using the specified locations from settings.
         toolchains_paths = [
-            os.path.join(loc, "cmake", "toolchain", f'{self.platform}.cmake')
+            os.path.join(loc, "cmake", "toolchain", f"{self.platform}.cmake")
             for loc in toolchain_locations
             if loc is not None
         ]

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -105,11 +105,7 @@ class CMakeHandler:
             cmake_target = (
                 module
                 if target == ""
-                else (
-                    f"{module}_{target}".lstrip("_")
-                    if not top_target
-                    else target
-                )
+                else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]
         environment = {} if environment is None else copy.copy(environment)

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -107,9 +107,7 @@ def add_to_cmake(list_file: Path, comp_path: Path):
         print("Already added to CMakeLists.txt")
         return True
 
-    if not confirm(
-        f"Add component {comp_path} to {list_file} at end of file?"
-    ):
+    if not confirm(f"Add component {comp_path} to {list_file} at end of file?"):
         return False
 
     lines.append(addition)
@@ -197,9 +195,7 @@ def add_port_to_cmake(list_file: Path, comp_path: Path):
     index += 1
     while "CMAKE_CURRENT_LIST_DIR" in lines[index]:
         index += 1
-    if not confirm(
-        f"Add port {comp_path} to {list_file} ports in CMakeLists.txt?"
-    ):
+    if not confirm(f"Add port {comp_path} to {list_file} ports in CMakeLists.txt?"):
         return False
 
     addition = '    "${{CMAKE_CURRENT_LIST_DIR}}/{}"\n'.format(comp_path)
@@ -368,9 +364,7 @@ def get_port_input(namespace):
     args_done = False
     arg_list = []
     port_name = get_valid_input(f'Port Name [{defaults["port_name"]}]: ')
-    short_description = input(
-        f'Short Description [{defaults["short_description"]}]: '
-    )
+    short_description = input(f'Short Description [{defaults["short_description"]}]: ')
     dir_name = get_valid_input(f'Directory Name [{defaults["dir_name"]}]: ')
     namespace = get_valid_input(f'Port Namespace [{defaults["namespace"]}]: ')
     while not args_done:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

We specifically checked in bad formatting in #50 as the branch was inadvertently deleted and we didn't want to lose the change trying to find something to reformat.  This corrects the formatting as a follow-up.