### PR TITLE
lestarch: fixing random crash from unstripped cache variables

### DIFF
--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -60,7 +60,9 @@ class CMakeHandler:
             # newer CMake options that aren't used by older versions of CMake won't be set in the cache
             if actual is None:
                 continue
-            if str(expected) != actual:
+            expected = str(expected).strip()
+            actual = str(actual).strip()
+            if expected != actual:
                 raise CMakeInconsistentCacheException(key, expected, actual)
 
     def execute_known_target(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Strips checking of cache variables ensuring they compare well.