### PR TITLE
lestarch: checking for expected package versions

### DIFF
--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -40,7 +40,7 @@ class ArgValidationException(Exception):
 
 
 def package_version_check():
-    """Checks the version of the packages installed match the expected packages of the fprime metapackage"""
+    """Checks the version of the packages installed match the expected packages of the fprime aggregate package"""
     try:
         import pkg_resources
 
@@ -52,9 +52,9 @@ def package_version_check():
                 result = pkg_resources.working_set.find(requirement)
                 if not result:
                     print(f"[WARNING] Expected package {requirement} not found")
-            except pkg_resources.VersionConflict as vce:
+            except pkg_resources.VersionConflict as version_exception:
                 print(
-                    f"[WARNING] Expected package version {vce.req} but found {vce.dist}"
+                    f"[WARNING] Expected package version {version_exception.req} but found {version_exception.dist}"
                 )
     except (ImportError, pkg_resources.DistributionNotFound):
         print("[WARNING] 'fprime' package not installed, skipping tools version check")

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -39,6 +39,27 @@ class ArgValidationException(Exception):
     """An exception used for argument validation"""
 
 
+def package_version_check():
+    """Checks the version of the packages installed match the expected packages of the fprime metapackage"""
+    try:
+        import pkg_resources
+
+        fprime_distribution = pkg_resources.get_distribution("fprime")
+        tools_requirements = fprime_distribution.requires()
+
+        for requirement in tools_requirements:
+            try:
+                result = pkg_resources.working_set.find(requirement)
+                if not result:
+                    print(f"[WARNING] Expected package {requirement} not found")
+            except pkg_resources.VersionConflict as vce:
+                print(
+                    f"[WARNING] Expected package version {vce.req} but found {vce.dist}"
+                )
+    except (ImportError, pkg_resources.DistributionNotFound):
+        print("[WARNING] 'fprime' package not installed, skipping tools version check")
+
+
 def validate(parsed, unknown):
     """
     Validate rules to ensure that the args are properly consistent. This will also generate a set of validated arguments
@@ -156,6 +177,7 @@ def parse_args(args):
 
 def utility_entry(args):
     """Main interface to F prime utility"""
+    package_version_check()
     parsed, cmake_args, make_args, parser, runners = parse_args(args)
 
     try:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds in a version check when the fprime metapacakage is installed. This ensures the tools are the right version, or at least the user has been warned that the tools are of different versions.

It uses the python package versions and checks them against the fprime metapackage.  

## Rationale

Fixes nasa/fprime#1341