### PR TITLE
Replace conditional assignment to a variable with an if expression

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -55,9 +55,7 @@ class ArrayType(DictionaryType):
 
         :return dictionary of member names to python values of member keys
         """
-        if self._val is None:
-            return None
-        return [item.val for item in self._val]
+        return None if self._val is None else [item.val for item in self._val]
 
     @property
     def formatted_val(self) -> list:

--- a/src/fprime/common/models/serialize/type_base.py
+++ b/src/fprime/common/models/serialize/type_base.py
@@ -75,9 +75,7 @@ class ValueType(BaseType):
 
     def __eq__(self, other):
         """Check equality between types"""
-        if type(other) != type(self):
-            return False
-        return self._val == other._val
+        return False if type(other) != type(self) else self._val == other._val
 
     @property
     def val(self):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| serialize module |
|**_Affected Architectures(s)_**| serializer |
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**|  n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to replace two conditional assignments to a variable by if expressions.

## Rationale

The ternary operator is represented by the conditional expression syntax of Python. This is a significant improvement in the case where the conditional expression is :

- short and can be written on a single line

- not difficult (no nested expressions or long boolean strings).

## Testing/Review Recommendations

(void)

## Future Work

(void)
