### PR TITLE
Add a single value to the dictionary directly rather than using update()

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -323,12 +323,10 @@ class Build:
             v3_autocoder_directory.exists()
             and self.build_type == BuildType.BUILD_TESTING
         ):
-            cmake_args.update({"BUILD_TESTING": "ON"})
-            cmake_args.update(
-                {"CMAKE_BUILD_TYPE": cmake_args.get("CMAKE_BUILD_TYPE", "Debug")}
-            )
+            cmake_args["BUILD_TESTING"] = "ON"
+            cmake_args["CMAKE_BUILD_TYPE"] = cmake_args.get("CMAKE_BUILD_TYPE", "Debug")
         elif self.build_type == BuildType.BUILD_TESTING:
-            cmake_args.update({"CMAKE_BUILD_TYPE": "Testing"})
+            cmake_args["CMAKE_BUILD_TYPE"] = "Testing"
         return cmake_args
 
     def get_module_name(self, path: Path):

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -53,7 +53,7 @@ def run_fbuild_cli(
         print(f"[INFO] Generating build directory at: {build.build_dir}")
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
         if toolchain is not None:
-            cmake_args.update({"CMAKE_TOOLCHAIN_FILE": toolchain})
+            cmake_args["CMAKE_TOOLCHAIN_FILE"] = toolchain
         build.generate(cmake_args)
     elif parsed.command == "purge":
         # Since purge does not load its "base", we need to overload the platform

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -83,7 +83,7 @@ def validate(parsed, unknown):
     # Build type only for generate, jobs only for non-generate
     elif parsed.command in Target.get_all_targets():
         parsed.settings = None  # Force to load from cache if possible
-        make_args.update({"--jobs": (1 if parsed.jobs <= 0 else parsed.jobs)})
+        make_args["--jobs"] = 1 if parsed.jobs <= 0 else parsed.jobs
     # Check if any arguments are still unknown
     if unknown:
         runnable = f"{os.path.basename(sys.argv[0])} {parsed.command}"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| fbuild |
|**_Affected Architectures(s)_**| none|
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**|  n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to change the way to add a single value to the dictionary by doing it directly rather than using update() when possible.

## Rationale

It is easier to add an entry to a dictionary directly rather than using the update() method. It also removes the overhead of creating another dictionary and calling a method, which should improve performance slightly.

## Testing/Review Recommendations

(void)

## Future Work

(void)
