### PR TITLE
Replace empty collection comparisons w/ a more idiomatic unary operator

### DIFF
--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -107,7 +107,7 @@ class CMakeHandler:
             module = self.get_cmake_module(path, build_dir)
             cmake_target = (
                 module
-                if target == ""
+                if not target:
                 else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]
@@ -556,7 +556,7 @@ class CMakeHandler:
                 appendable.append(line)
                 # Streams are EOF when the line returned is empty. Once this occurs, we are responsible for closing the
                 # stream and thus closing the select loop. Empty strings need not be printed.
-                if line == "":
+                if not line:
                     key.fileobj.close()
                     continue
                 # Forwards output to screen.  Assuming a PTY is used, then coloring highlights should be automatically

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -107,7 +107,7 @@ class CMakeHandler:
             module = self.get_cmake_module(path, build_dir)
             cmake_target = (
                 module
-                if not target
+                if target == ""
                 else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -107,7 +107,7 @@ class CMakeHandler:
             module = self.get_cmake_module(path, build_dir)
             cmake_target = (
                 module
-                if not target:
+                if not target
                 else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -391,7 +391,7 @@ def get_port_input(namespace):
 
     # Fill in blank values with defaults
     for key in values:
-        if not values[key]:
+        if values[key] == "":
             values[key] = defaults[key]
     return values
 

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -391,7 +391,7 @@ def get_port_input(namespace):
 
     # Fill in blank values with defaults
     for key in values:
-        if values[key] == "":
+        if not values[key]:
             values[key] = defaults[key]
     return values
 

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -54,7 +54,7 @@ class IniSettings:
         all_paths = parser.get(section, key, fallback="").split(":")
         expanded = []
         for path in all_paths:
-            if not path or path is None:
+            if not path:
                 continue
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -54,7 +54,7 @@ class IniSettings:
         all_paths = parser.get(section, key, fallback="").split(":")
         expanded = []
         for path in all_paths:
-            if path == "" or path is None:
+            if not path or path is None:
                 continue
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -66,7 +66,7 @@ def format_string_template(format_str, given_values):
             elif all([not ignore_int, str(conversion_type).lower() == "d"]):
                 format_template += f"{conversion_type}"
 
-        return "{}" if format_template == "" else "{:" + format_template + "}"
+        return "{}" if not format_template else "{:" + format_template + "}"
 
     def convert_include_all(match_obj):
         return convert(match_obj, ignore_int=False)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| fbuild |
|**_Affected Architectures(s)_**| (void )|
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| see CI results |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to replace the comparison of empty collections with a more idiomatic unary operator.

## Rationale

This refactoring follows the [PEP 8 programming recommendations](https://peps.python.org/pep-0008/#programming-recommendations), in particular the following recommendation: ``For sequences, (strings, lists, tuples), use the fact that empty sequences are false`` in the context of comparisons.

## Testing/Review Recommendations

(void)

## Future Work

(void)
