### PR TITLE
Removal of the unnecessary call to keys() when iterating over a dictionary

### DIFF
--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -86,7 +86,7 @@ def test_get_fprime_configuration():
         ),
         "external": ("/home/user11/Proj", "/opt/lib1;/opt/lib2", "/opt/fprime"),
     }
-    for key in test_data.keys():
+    for key in test_data:
         build_dir = os.path.join(get_data_dir(), key)
         # Test all path, truth pairs
         values = get_cmake_builder().get_fprime_configuration(configs, build_dir)
@@ -108,7 +108,7 @@ def test_get_include_locations():
         ],
         "external": ["/home/user11/Proj", "/opt/lib1", "/opt/lib2", "/opt/fprime"],
     }
-    for key in test_data.keys():
+    for key in test_data:
         build_dir = os.path.join(get_data_dir(), key)
         paths = list(get_cmake_builder().get_include_locations(build_dir))
         assert paths == test_data[key]
@@ -162,7 +162,7 @@ def test_get_include_info():
         ],
     }
     # Run through all the above data look for matching answers
-    for key in test_data.keys():
+    for key in test_data:
         build_dir = os.path.join(get_data_dir(), key)
         # Test all path, truth pairs
         for path, truth in test_data.get(key):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| fbuild/test_build.py |
|**_Affected Architectures(s)_**| (void) |
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI runs |
|**_Unit Tests Pass (y/n)_**| Let CI runs |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to remove unnecessary calls to ``keys()`` when iterating over a dictionary.

## Rationale

The call to ``keys()`` is not necessary when iterating over a dictionary using its keys, as the default behavior when iterating over a dictionary is to iterate over the keys.

The code is now slightly cleaner and easier to read, and avoids a function call (which slightly improves performance).

## Testing/Review Recommendations

(void)

## Future Work

(void)
