### PR TITLE
Remove nnecessary `elif` / `else` block after ``raise`` and``continue``

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -42,7 +42,7 @@ class ArrayType(DictionaryType):
         """Validates the values of the array"""
         if not isinstance(val, (tuple, list)):
             raise TypeMismatchException(list, type(val))
-        elif len(val) != cls.LENGTH:
+        if len(val) != cls.LENGTH:
             raise ArrayLengthException(cls.MEMBER_TYPE, cls.LENGTH, len(val))
         for i in range(cls.LENGTH):
             cls.MEMBER_TYPE.validate(val[i])

--- a/src/fprime/common/models/serialize/enum_type.py
+++ b/src/fprime/common/models/serialize/enum_type.py
@@ -38,7 +38,7 @@ class EnumType(DictionaryType):
         for member in enum_dict.keys():
             if not isinstance(member, str):
                 raise TypeMismatchException(str, type(member))
-            elif not isinstance(enum_dict[member], int):
+            if not isinstance(enum_dict[member], int):
                 raise TypeMismatchException(int, enum_dict[member])
         return DictionaryType.construct_type(cls, name, ENUM_DICT=enum_dict)
 

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -50,11 +50,11 @@ class SerializableType(DictionaryType):
             # Check each of these members for correct types
             if not isinstance(member_name, str):
                 raise TypeMismatchException(str, type(member_name))
-            elif not issubclass(member_type, BaseType):
+            if not issubclass(member_type, BaseType):
                 raise TypeMismatchException(BaseType, member_type)
-            elif format_string is not None and not isinstance(format_string, str):
+            if format_string is not None and not isinstance(format_string, str):
                 raise TypeMismatchException(str, type(format_string))
-            elif description is not None and not isinstance(description, str):
+            if description is not None and not isinstance(description, str):
                 raise TypeMismatchException(str, type(description))
         return DictionaryType.construct_type(cls, name, MEMBER_LIST=member_list)
 
@@ -64,7 +64,7 @@ class SerializableType(DictionaryType):
         # Ensure that the supplied value is a dictionary
         if not isinstance(val, dict):
             raise TypeMismatchException(dict, type(val))
-        elif len(val) != len(cls.MEMBER_LIST):
+        if len(val) != len(cls.MEMBER_LIST):
             raise IncorrectMembersException([name for name, _, _, _ in cls.MEMBER_LIST])
         # Now validate each field as defined via the value
         for member_name, member_type, _, _ in cls.MEMBER_LIST:

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -39,7 +39,7 @@ class StringType(type_base.DictionaryType):
         """Validates that this is a string"""
         if not isinstance(val, str):
             raise TypeMismatchException(str, type(val))
-        elif cls.MAX_LENGTH is not None and len(val) > cls.MAX_LENGTH:
+        if cls.MAX_LENGTH is not None and len(val) > cls.MAX_LENGTH:
             raise StringSizeException(len(val), cls.MAX_LENGTH)
 
     def serialize(self):
@@ -68,7 +68,7 @@ class StringType(type_base.DictionaryType):
                     f"Not enough data to deserialize string data. Needed: {val_size} Left: {len(data[offset + 2 :])}"
                 )
             # Deal with a string that is larger than max string
-            elif self.MAX_LENGTH is not None and val_size > self.MAX_LENGTH:
+            if self.MAX_LENGTH is not None and val_size > self.MAX_LENGTH:
                 raise StringSizeException(val_size, self.MAX_LENGTH)
             self.val = data[offset + 2 : offset + 2 + val_size].decode(DATA_ENCODING)
         except struct.error:

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -107,7 +107,7 @@ class CMakeHandler:
             module = self.get_cmake_module(path, build_dir)
             cmake_target = (
                 module
-                if target == ""
+                if not target:
                 else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]
@@ -556,7 +556,7 @@ class CMakeHandler:
                 appendable.append(line)
                 # Streams are EOF when the line returned is empty. Once this occurs, we are responsible for closing the
                 # stream and thus closing the select loop. Empty strings need not be printed.
-                if line == "":
+                if not line:
                     key.fileobj.close()
                     continue
                 # Forwards output to screen.  Assuming a PTY is used, then coloring highlights should be automatically

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -107,7 +107,7 @@ class CMakeHandler:
             module = self.get_cmake_module(path, build_dir)
             cmake_target = (
                 module
-                if not target
+                if target == ""
                 else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -107,7 +107,7 @@ class CMakeHandler:
             module = self.get_cmake_module(path, build_dir)
             cmake_target = (
                 module
-                if not target:
+                if not target
                 else (f"{module}_{target}".lstrip("_") if not top_target else target)
             )
         run_args = ["--build", build_dir]

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -185,7 +185,7 @@ class GcovrAcHelper(ExecutableAction):
         for path in parent_path.iterdir():
             if path.absolute() in excludes:
                 continue
-            elif path.is_file() and path.suffix in self.EXTENSION_TRIGGER:
+            if path.is_file() and path.suffix in self.EXTENSION_TRIGGER:
                 self.copy_gcda_pair(destination, path)
             elif path.is_file() and path.name.endswith("Ac.hpp"):
                 self.copy_safe(path, destination / path.name)

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -391,7 +391,7 @@ def get_port_input(namespace):
 
     # Fill in blank values with defaults
     for key in values:
-        if not values[key]:
+        if values[key] == "":
             values[key] = defaults[key]
     return values
 

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -391,7 +391,7 @@ def get_port_input(namespace):
 
     # Fill in blank values with defaults
     for key in values:
-        if values[key] == "":
+        if not values[key]:
             values[key] = defaults[key]
     return values
 

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -54,7 +54,7 @@ class IniSettings:
         all_paths = parser.get(section, key, fallback="").split(":")
         expanded = []
         for path in all_paths:
-            if not path or path is None:
+            if not path:
                 continue
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -54,7 +54,7 @@ class IniSettings:
         all_paths = parser.get(section, key, fallback="").split(":")
         expanded = []
         for path in all_paths:
-            if path == "" or path is None:
+            if not path or path is None:
                 continue
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -73,7 +73,7 @@ def validate(parsed, unknown):
     # Check platforms for existing toolchain, unless the default is specified.
     if not hasattr(parsed, "command") or parsed.command is None:
         raise ArgValidationException("'fprime-util' not supplied sub-command argument")
-    elif parsed.command == "generate":
+    if parsed.command == "generate":
         d_args = {
             match.group(1): match.group(2)
             for match in [CMAKE_REG.match(arg) for arg in unknown]

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -66,7 +66,7 @@ def format_string_template(format_str, given_values):
             elif all([not ignore_int, str(conversion_type).lower() == "d"]):
                 format_template += f"{conversion_type}"
 
-        return "{}" if format_template == "" else "{:" + format_template + "}"
+        return "{}" if not format_template else "{:" + format_template + "}"
 
     def convert_include_all(match_obj):
         return convert(match_obj, ignore_int=False)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR introduces the following changes:

- Removal of unnecessary else/elif used after raise
- Removal of an unnecessary elif / else block after continue

## Rationale

- The use of 'else' or 'elif' becomes redundant and can be dropped if the last statement under the main 'if/elif' block is a 'continue' statement. In case of an 'elif' after 'continue', it can be written as a separate 'if' block. For 'else' blocks after 'continue', the statements can be moved out of the 'else' block.

- The 'raise' statement disrupts the control flow, as it allows to exit the block. It is recommended to check other conditions with another 'if' statement and to get rid of 'else' statements, which are useless.

## Testing/Review Recommendations

(void)

## Future Work

(void)
