### PR TITLE
Turns a method into a staticmethod because no `self` is used.

### DIFF
--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -91,7 +91,8 @@ class TimeType(type_base.BaseType):
         self.__secs = fprime.common.models.serialize.numerical_types.U32Type(seconds)
         self.__usecs = fprime.common.models.serialize.numerical_types.U32Type(useconds)
 
-    def _check_useconds(self, useconds):
+    @staticmethod
+    def _check_useconds(useconds):
         """
         Checks if a given microsecond value is valid.
 
@@ -104,7 +105,8 @@ class TimeType(type_base.BaseType):
         if (useconds < 0) or (useconds > 999999):
             raise TypeRangeException(useconds)
 
-    def _check_time_base(self, time_base):
+    @staticmethod
+    def _check_time_base(time_base):
         """
         Checks if a given TimeBase value is valid.
 

--- a/src/fprime/fbuild/target.py
+++ b/src/fprime/fbuild/target.py
@@ -39,7 +39,8 @@ class ExecutableAction(ABC):
         """Set scope of this action"""
         self.scope = scope
 
-    def is_supported(self, builder: "Build", context: Path):
+    @staticmethod
+    def is_supported(builder: "Build", context: Path):
         """Is supported by the list of build target names
 
         Checks if the build target names supplied will support this target. Is overridden by subclasses.
@@ -60,11 +61,13 @@ class ExecutableAction(ABC):
     ):
         """Executes the given target"""
 
-    def allows_pass_args(self):
+    @staticmethod
+    def allows_pass_args():
         """Target allows pass-through arguments"""
         return False
 
-    def pass_handler(self):
+    @staticmethod
+    def pass_handler():
         """Handler of pass-through args"""
         return None
 

--- a/src/fprime/fbuild/target.py
+++ b/src/fprime/fbuild/target.py
@@ -39,8 +39,7 @@ class ExecutableAction(ABC):
         """Set scope of this action"""
         self.scope = scope
 
-    @staticmethod
-    def is_supported(builder: "Build", context: Path):
+    def is_supported(self, builder: "Build", context: Path):
         """Is supported by the list of build target names
 
         Checks if the build target names supplied will support this target. Is overridden by subclasses.
@@ -61,13 +60,11 @@ class ExecutableAction(ABC):
     ):
         """Executes the given target"""
 
-    @staticmethod
-    def allows_pass_args():
+    def allows_pass_args(self):
         """Target allows pass-through arguments"""
         return False
 
-    @staticmethod
-    def pass_handler():
+    def pass_handler(self):
         """Handler of pass-through args"""
         return None
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to transform some methods into static methods when no self is used.

## Rationale

These methods do not use their bound instance.
It is advisable to decorate this type of method with the ``@staticmethod`` decorator, so that Python does not have to instantiate a linked method for each instance of this class, thus saving memory and computation. 

## Testing/Review Recommendations

(void)

## Future Work

(void)