### PR TITLE
Fix anti-pattern comparison test: use of `is` when comparing the `type` of two objects

### DIFF
--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -31,7 +31,7 @@ def get_data_dir():
 
     :return:
     """
-    if type(get_cmake_builder()) == fprime.fbuild.cmake.CMakeHandler:
+    if type(get_cmake_builder()) is fprime.fbuild.cmake.CMakeHandler:
         return os.path.join(os.path.dirname(__file__), "cmake-data")
     raise Exception(
         f"Test data directory not setup for {type(get_cmake_builder())} builder class"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to correct an antipattern issue regarding a bad comparison identity test.

## Rationale

It is recommended to use the identity test ( is ) instead of the equality test ( == ) when we need to compare the types of two objects. 

## Testing/Review Recommendations

(void)

## Future Work

(void)