### PR TITLE
lestarch: loosening package requirements

### DIFF
--- a/.github/workflows/fprime-tools-ci.yml
+++ b/.github/workflows/fprime-tools-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         fprime-version: [[NASA-v1.5.3, 99cef07], [v2.0.0, 521516c], [v3.0.0, 521516c], [devel, 521516c]]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -81,22 +81,20 @@ to interact with the data coming from the FSW.
     # Requires Python 3.6+
     python_requires=">=3.6",
     install_requires=[
-        "lxml==4.6.3",
-        "Markdown==3.3.4",
-        "MarkupSafe<2.0.0",
-        "pexpect==4.8.0",
-        "pytest==6.2.4",
-        "Cheetah3==3.2.6",
-        "setuptools-scm==6.0.1",
-        "cookiecutter==1.7.2",
-        "gcovr==5.0",
+        "lxml",
+        "Markdown",
+        "pexpect",
+        "pytest",
+        "Cheetah3",
+        "cookiecutter",
+        "gcovr",
     ],
     extras_require={
         "dev": [
             "black==21.5b1",
-            "pylama==7.7.1",
-            "pylint==2.8.2",
-            "pre-commit==2.12.1",
+            "pylama",
+            "pylint",
+            "pre-commit",
             "sphinx",
             "sphinxcontrib.mermaid",
             "sphinx-rtd-theme",
@@ -106,7 +104,7 @@ to interact with the data coming from the FSW.
         ]
     },
     # Setup and test requirements, not needed by normal install
-    setup_requires=["pytest-runner==5.3.0", "setuptools_scm==6.0.1"],
+    setup_requires=["pytest-runner", "setuptools_scm"],
     tests_require=["pytest"],
     # Create a set of executable entry-points for running directly from the package
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -71,23 +71,23 @@ to interact with the data coming from the FSW.
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    # Requires Python 3.6+
-    python_requires=">=3.6",
+    # Requires Python 3.7+
+    python_requires=">=3.7",
     install_requires=[
-        "lxml",
-        "Markdown",
-        "pexpect",
-        "pytest",
-        "Cheetah3",
-        "cookiecutter",
-        "gcovr",
+        "lxml>=4.6.3, <5.0.0",
+        "Markdown>=3.3.4, <4.0.0",
+        "pexpect>=4.8.0, <5.0.0",
+        "pytest>=6.2.4, <7.0.0",
+        "Cheetah3>=3.2.6, <4.0.0",
+        "cookiecutter>=1.7.2, <2.0.0",
+        "gcovr>=5.0, <6.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The recommended approach for python packages is to ship a `setup.py` (a.k.a python package) with the most minimal of requirement specifiers and let PIP to sort out the appropriate version set.  This requires loose versions in our packages.

To get a "working set" of versions that always works, `fprime` will publish a `requirements.txt` that fixes all versions across the project.



