### PR TITLE
Refactoring by swapping if-expr to avoid negation

### DIFF
--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -112,7 +112,7 @@ class SerializableType(DictionaryType):
         Note 2: If a member is an array will call array formatted_val
         :return a formatted dict
         """
-        result = dict()
+        result = {}
         for member_name, _, member_format, _ in self.MEMBER_LIST:
             value_object = self._val[member_name]
             if isinstance(value_object, (array_type.ArrayType, SerializableType)):

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -108,7 +108,9 @@ class CMakeHandler:
             cmake_target = (
                 module
                 if target == ""
-                else (f"{module}_{target}".lstrip("_") if not top_target else target)
+                else target
+                if top_target
+                else f"{module}_{target}".lstrip("_")
             )
         run_args = ["--build", build_dir]
         environment = {} if environment is None else copy.copy(environment)

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -111,7 +111,7 @@ class CMakeHandler:
                 cmake_target = target
             else:
                 cmake_target = f"{module}_{target}".lstrip("_")
-            
+
         run_args = ["--build", build_dir]
         environment = {} if environment is None else copy.copy(environment)
         if self.verbose:

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -105,13 +105,13 @@ class CMakeHandler:
             cmake_target = target
         else:
             module = self.get_cmake_module(path, build_dir)
-            cmake_target = (
-                module
-                if target == ""
-                else target
-                if top_target
-                else f"{module}_{target}".lstrip("_")
-            )
+            if target == "":
+                cmake_target = module
+            elif top_target:
+                cmake_target = target
+            else:
+                cmake_target = f"{module}_{target}".lstrip("_")
+            
         run_args = ["--build", build_dir]
         environment = {} if environment is None else copy.copy(environment)
         if self.verbose:

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -273,7 +273,7 @@ class Gcovr(ExecutableAction):
             "--print-summary",
             "--txt",
             f"{coverage_output_dir}/summary.txt",
-            f"--html-details",
+            "--html-details",
             f"{coverage_output_dir}/coverage{'-all' if self.scope == TargetScope.GLOBAL else ''}.html",
         ]
         cli_args.extend(args[1])

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -66,7 +66,7 @@ def format_string_template(format_str, given_values):
             elif all([not ignore_int, str(conversion_type).lower() == "d"]):
                 format_template += f"{conversion_type}"
 
-        return "{}" if not format_template else "{:" + format_template + "}"
+        return "{:" + format_template + "}" if format_template else "{}"
 
     def convert_include_all(match_obj):
         return convert(match_obj, ignore_int=False)

--- a/test/fprime/common/models/serialize/test_types.py
+++ b/test/fprime/common/models/serialize/test_types.py
@@ -312,7 +312,7 @@ def test_serializable_basic_off_nominal():
         ("member2", StringType.construct_type("StringMember1", max_length=10), "%s"),
     ]
     serializable_type = SerializableType.construct_type(
-        f"BasicInvalidSerializable", member_list
+        "BasicInvalidSerializable", member_list
     )
 
     invalid_values = [


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims at swapping some "if" and "else" branches of two if expression to remove a negation.

Misc:
- remove two unneeded f-string format.
- improve dict creation to be more concide and improve perf.

## Rationale

Negative conditions are harder to read than positive conditions, so it is best to avoid them if possible. By swapping the if and else conditions, we can reverse the condition and make it positive.

## Testing/Review Recommendations

void

## Future Work

void
