### PR TITLE
Replace unused ``for`` index with underscore

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -110,7 +110,7 @@ class ArrayType(DictionaryType):
     def deserialize(self, data, offset):
         """Deserialize the members of the array"""
         values = []
-        for i in range(self.LENGTH):
+        for _ in range(self.LENGTH):
             item = self.MEMBER_TYPE()
             item.deserialize(data, offset)
             offset += item.getSize()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to replace an unused index in a ``for`` loop with an underscore.

## Rationale

This is a convention in Python to use ``_`` as a throwaway name for unused variables.
This reduces the workload on the reader and improves the understanding of the code by making it clear that it is safe to ignore the index.

Indeed, so when we see this in a ``for`` loop, it's immediately clear that the loop is just being used to repeat a block of code and that we don't care what value we're iterating on.


## Testing/Review Recommendations

void

## Future Work

void
