### PR TITLE
Inline variables returned immediately

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -88,9 +88,9 @@ class ArrayType(DictionaryType):
 
     def to_jsonable(self):
         """
-        JSONable type
+        JSONable array object format
         """
-        members = {
+        return {
             "name": self.__class__.__name__,
             "type": self.__class__.__name__,
             "size": self.LENGTH,
@@ -99,7 +99,6 @@ class ArrayType(DictionaryType):
             if self._val is None
             else [member.to_jsonable() for member in self._val],
         }
-        return members
 
     def serialize(self):
         """Serialize the array by serializing the elements one by one"""

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -29,10 +29,9 @@ class StringType(type_base.DictionaryType):
     @classmethod
     def construct_type(cls, name, max_length=None):
         """Constructs a new string type with given name and maximum length"""
-        temporary = type_base.DictionaryType.construct_type(
+        return type_base.DictionaryType.construct_type(
             cls, name, MAX_LENGTH=max_length
         )
-        return temporary
 
     @classmethod
     def validate(cls, val):
@@ -52,9 +51,8 @@ class StringType(type_base.DictionaryType):
         # Check string size before serializing
         elif self.MAX_LENGTH is not None and len(self.val) > self.MAX_LENGTH:
             raise StringSizeException(len(self.val), self.MAX_LENGTH)
-        # Pack the string size first then return the encoded data
-        buff = struct.pack(">H", len(self.val)) + self.val.encode(DATA_ENCODING)
-        return buff
+        # Pack the string size first then return the encoded data buffer
+        return struct.pack(">H", len(self.val)) + self.val.encode(DATA_ENCODING)
 
     def deserialize(self, data, offset):
         """

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -29,9 +29,7 @@ class StringType(type_base.DictionaryType):
     @classmethod
     def construct_type(cls, name, max_length=None):
         """Constructs a new string type with given name and maximum length"""
-        return type_base.DictionaryType.construct_type(
-            cls, name, MAX_LENGTH=max_length
-        )
+        return type_base.DictionaryType.construct_type(cls, name, MAX_LENGTH=max_length)
 
     @classmethod
     def validate(cls, val):

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -319,7 +319,7 @@ class CMakeHandler:
             This code might not work on non-GNU makefile variants of CMake as it depends on the "help" target
 
         Returns:
-            list of CMake make targets
+            list of contextual CMake make targets
         """
         if not self.cached_help_targets:
             run_args = ["--build", build_dir, "--target", "help"]
@@ -333,12 +333,11 @@ class CMakeHandler:
             ]
 
         prefix = self.get_cmake_module(path, build_dir)
-        contextual_make_targets = [
+        return [
             make.replace(prefix, "").strip("_")
             for make in self.cached_help_targets
             if make.startswith(prefix)
         ]
-        return contextual_make_targets
 
     @staticmethod
     def purge(build_dir):

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -26,8 +26,7 @@ def _get_project_path(builder: "Build", module: Union[str, Path]) -> Path:
         return module
     # Calculate the project path from the module name
     project_root = builder.get_settings(
-        "project_root",
-        builder.get_settings("framework_path", builder.build_dir.parent),
+        "project_root", builder.get_settings("framework_path", builder.build_dir.parent)
     )
     return Path(project_root) / module.replace("_", "/")
 

--- a/src/fprime/fpp/cli.py
+++ b/src/fprime/fpp/cli.py
@@ -50,17 +50,9 @@ def add_fpp_parsers(
         Tuple of dictionary mapping command name to processor, and command to parser
     """
     check_parser = subparsers.add_parser(
-        "fpp-check",
-        help="Runs fpp-check utility",
-        parents=[common],
-        add_help=False,
+        "fpp-check", help="Runs fpp-check utility", parents=[common], add_help=False
     )
     check_parser.add_argument(
-        "-u",
-        "--unconnected",
-        default=None,
-        help="write unconnected ports to file",
+        "-u", "--unconnected", default=None, help="write unconnected ports to file"
     )
-    return {
-        "fpp-check": run_fpp_check,
-    }, {"fpp-check": check_parser}
+    return {"fpp-check": run_fpp_check}, {"fpp-check": check_parser}

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -148,8 +148,7 @@ def parse_args(args):
         description=HelpText.long("global_help"),
     )
     subparsers = parser.add_subparsers(
-        description=HelpText.long("subparsers_description"),
-        dest="command",
+        description=HelpText.long("subparsers_description"), dest="command"
     )
 
     # Add all externally defined cli parser command to running functions

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -67,9 +67,9 @@ def print_info(
         )
         print("  ----------------------------------------------------------")
     # Artifact locations come afterwards
-    for build_type, (
-        build_artifact_location,
-        global_build_cache,
+    for (
+        build_type,
+        (build_artifact_location, global_build_cache),
     ) in build_infos.items():
         print(
             f"    {build_type.get_cmake_build_type()} build cache module directory: {build_artifact_location}"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The goal of this PR is to inline some variables to a ``return`` in case the declared variable is immediately returned.

## Rationale

Intermediate variables can be useful if they are used later as a parameter or condition, and their name can provide context for what the variable represents.
If returned by a function, the function name is present to indicate the type of result.

I took the liberty of removing these intermediate variables because they don't really add value.

Returning the result directly reduces the mental load of reading the function by shortening the code and removing an unnecessary variable.

## Testing/Review Recommendations

void

## Future Work

void
