### PR TITLE
Remove unnecessary `else` / `elif` used after `return`/`raise`

### DIFF
--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -47,7 +47,7 @@ class StringType(type_base.DictionaryType):
         if self.val is None:
             raise NotInitializedException(type(self))
         # Check string size before serializing
-        elif self.MAX_LENGTH is not None and len(self.val) > self.MAX_LENGTH:
+        if self.MAX_LENGTH is not None and len(self.val) > self.MAX_LENGTH:
             raise StringSizeException(len(self.val), self.MAX_LENGTH)
         # Pack the string size first then return the encoded data buffer
         return struct.pack(">H", len(self.val)) + self.val.encode(DATA_ENCODING)

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -294,6 +294,7 @@ class TimeType(type_base.BaseType):
             self.__usecs.val,
             self.__timeContext.val,
         )
+
     def get_datetime(self, tz=None):
         """
         Returns the python datetime object for UTC time

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -288,14 +288,12 @@ class TimeType(type_base.BaseType):
         # If we could convert to a valid datetime, use that, otherwise, format
         if dt:
             return dt.strftime("%Y-%m-%d %H:%M:%S%z")
-        else:
-            return "%s: %d.%06ds, context=%d" % (
-                TimeBase(self.__timeBase.val).name,
-                self.__secs.val,
-                self.__usecs.val,
-                self.__timeContext.val,
-            )
-
+        return "%s: %d.%06ds, context=%d" % (
+            TimeBase(self.__timeBase.val).name,
+            self.__secs.val,
+            self.__usecs.val,
+            self.__timeContext.val,
+        )
     def get_datetime(self, tz=None):
         """
         Returns the python datetime object for UTC time
@@ -355,8 +353,7 @@ class TimeType(type_base.BaseType):
         """Less than"""
         if isinstance(other, TimeType):
             return self.compare(self, other) < 0
-        else:
-            return self.get_float() < other
+        return self.get_float() < other
 
     def __le__(self, other):
         """Less than or equal"""
@@ -369,29 +366,25 @@ class TimeType(type_base.BaseType):
         """Equal"""
         if isinstance(other, TimeType):
             return self.compare(self, other) == 0
-        else:
-            return self.get_float() == other
+        return self.get_float() == other
 
     def __ne__(self, other):
         """Not equal"""
         if isinstance(other, TimeType):
             return self.compare(self, other) != 0
-        else:
-            return self.get_float() != other
+        return self.get_float() != other
 
     def __gt__(self, other):
         """Greater than"""
         if isinstance(other, TimeType):
             return self.compare(self, other) > 0
-        else:
-            return self.get_float() > other
+        return self.get_float() > other
 
     def __ge__(self, other):
         """Greater than or equal"""
         if isinstance(other, TimeType):
             return self.compare(self, other) >= 0
-        else:
-            return self.get_float() >= other
+        return self.get_float() >= other
 
     # The following helper methods enable support for arithmetic operations on TimeTypes.
 

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -332,7 +332,7 @@ def is_valid_name(word: str):
     for char in invalid_characters:
         if isinstance(word, str) and char in word:
             return char
-        elif not isinstance(word, str):
+        if not isinstance(word, str):
             raise ValueError("Incorrect usage of is_valid_name")
     return "valid"
 

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -115,7 +115,7 @@ def template(
     """
     if parsed.component and not parsed.port:
         return new_component(build.deployment, parsed.platform, parsed.verbose, build)
-    elif parsed.port and not parsed.component:
+    if parsed.port and not parsed.component:
         return new_port(build.deployment, build)
     print("[ERROR] Use --component or --port, not both.", file=sys.stderr)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The goal of this PR is to remove unnecessary `else` / `elif` used after `return`/`raise`.

## Rationale

If the last statement of the main `if/elif` block is a `return` statement, the use of `else` or `elif` becomes superfluous and can be omitted. If an `elif` follows a `return`, it can be written as a separate `if` block.
Instructions can be moved out of `else` blocks after a `return`.

Refactoring the code in this way can improve readability and make it easier to maintain.

## Testing/Review Recommendations

void

## Future Work

void
