### PR TITLE
Use set comprehension directly instead of calling set()

### DIFF
--- a/src/fprime/util/versioning.py
+++ b/src/fprime/util/versioning.py
@@ -32,7 +32,7 @@ def get_version(package: str, requirements: Path):
         )
 
     # Collapse versions that match
-    versions = list(set(line.split("==")[-1].split("@")[-1] for line in valid_lines))
+    versions = list({line.split("==")[-1].split("@")[-1] for line in valid_lines})
     if len(versions) != 1:
         raise VersionException(
             f"Conflicting versions specified for {package}: {versions}"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The goal of this PR is to use ``set`` comprehensions directly instead of calling ``set()``.

## Rationale

The Pythonic way to create a set from a generator is to use comprehensions. It is not necessary to use set around a generator expression to get an object of that type, since there are understandings for those types.
Using comprehensions instead of methods is slightly shorter.

## Testing/Review Recommendations

void

## Future Work

void
