### PR TITLE
Remove explicit inheritance of `object` class in `HelpText` class

### DIFF
--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -276,7 +276,7 @@ and components in fprime. The code has not been updated to use FPP models. Pleas
 }
 
 
-class HelpText(object):
+class HelpText:
     """
     There are two styles of help text: short (for argument descriptions) and long for full descriptions. This function
     will take a context key (command name, mnemonic, or other string) to lookup the full help text. The short help text


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The purpose of this PR is to remove the explicit inheritance of the ``HelpText`` class from the ``object`` class. 

## Rationale

In Python 3, the inheritance of the ``object`` class is implicit, and can therefore be safely removed from the bases. [ref](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object)

## Testing/Review Recommendations

void

## Future Work

void
