### PR TITLE
Remove unnecessary `None` provided as default

### DIFF
--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -55,7 +55,7 @@ class CMakeHandler:
     def validate_cmake_cache(self, cmake_args, build_dir):
         cmake_cache = self._read_cache(build_dir)
         for key, expected in cmake_args.items():
-            actual = cmake_cache.get(key, None)
+            actual = cmake_cache.get(key)
             # Allow expected variables not to be set in cache.
             # When building with a newer version of fprime-util and an older version of F prime,
             # newer CMake options that aren't used by older versions of CMake won't be set in the cache
@@ -358,7 +358,7 @@ class CMakeHandler:
         """
         cache = self._read_cache(build_dir)
         # Reads cache values suppressing KeyError, {}.get(x, default=None)
-        miner = lambda x: cache.get(x, None)
+        miner = lambda x: cache.get(x)
         return tuple(map(miner, keys))
 
     def _read_cache(self, build_dir):

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -445,7 +445,7 @@ def new_port(deployment: Path, build: Build):
         else:
             add_port_to_cmake(str(path_to_cmakelists), fname)
 
-        if proj_root_found is False:
+        if not proj_root_found:
             print(
                 "[INFO] No project root found. Created port without adding to build system nor generating implementation."
             )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The purpose of this PR is to unnecessary `None` provided as default in dictionnary `get()` method.

## Rationale

It is not necessary to provide `None` as a default value when the key is not present in the dictionary because get implicitly returns `None`.

## Testing/Review Recommendations

void

## Future Work

void
