### PR TITLE
Simplify `if` expression by using `or`

### DIFF
--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -140,7 +140,7 @@ class IniSettings:
                 settings["settings_file"],
                 key != "install_dest",
             )
-            value = paths_list if paths_list else get_default_value()
+            value = paths_list or get_default_value()
         else:
             raise FprimeSettingsException("Invalid settings specification")
         return value


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The purpose of this PR is to replace one `if` expression that compares to a target with `or`.

## Rationale

We end up setting a value if it is `True`, and otherwise using a default value.

The version with `or` is a little easier to read and avoids duplicating `path_list`.

It works because the left side is evaluated first. If it is evaluated to `True`, `value` will be set to `path_list` and the right side will not be evaluated.
If the result is `False`, the right side will be evaluated and the `value` will be set as the default.


## Testing/Review Recommendations

void

## Future Work

void
