### PR TITLE
Refactoring TimeType.compare/__le__

### DIFF
--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -250,11 +250,7 @@ class TimeType(type_base.BaseType):
 
         # Compare usecs
         usec_cmp = cmp(t1.useconds, t2.useconds)
-        if usec_cmp != 0:
-            return usec_cmp
-
-        # Compare contexts
-        return cmp(t1.timeContext, t2.timeContext)
+        return usec_cmp if usec_cmp != 0 else cmp(t1.timeContext, t2.timeContext)
 
     def __str__(self):
         """

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -356,8 +356,7 @@ class TimeType(type_base.BaseType):
         """Less than or equal"""
         if isinstance(other, TimeType):
             return self.compare(self, other) <= 0
-        else:
-            return self.get_float() <= other
+        return self.get_float() <= other
 
     def __eq__(self, other):
         """Equal"""

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -360,7 +360,7 @@ class CMakeHandler:
         """
         cache = self._read_cache(build_dir)
         # Reads cache values suppressing KeyError, {}.get(x, default=None)
-        miner = lambda x: cache.get(x)
+        miner = cache.get
         return tuple(map(miner, keys))
 
     def _read_cache(self, build_dir):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The purpose of this PR is to:
1. replace one`if` statement with `if` expression in `TimeType.compare`
2. remove unnecessary lambda function in `CMakeHandler.purge`
3. remove unnecessary `else` statement used after `return` in `TimeType.__le__`.

## Rationale

1. Code readability
2. A lambda that calls a function without modifying any of its parameters is unnecessary. It is preferred to use the function `cache.get` directly as the lambda function calls the same function without any modifications.
3. In the case of an `else` block after `return`, the statements can be shifted out of `else` to improve code readability.


## Testing/Review Recommendations

void

## Future Work

void
