### PR TITLE
Replace LGTM with Github Actions

### DIFF
--- a/.github/actions/codeql/security-pack.yml
+++ b/.github/actions/codeql/security-pack.yml
@@ -1,0 +1,4 @@
+name: "CodeQL security and quality"
+
+queries: 
+  - uses: security-and-quality

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -9,6 +9,7 @@ cmp
 commonprefix
 config
 configparser
+configs
 confparse
 consts
 contextmanager
@@ -30,6 +31,7 @@ deserialization
 deserialize
 deserialized
 deserializer
+deserializes
 dest
 devnull
 dfl
@@ -65,6 +67,7 @@ fpp
 fromkeys
 fromtimestamp
 func
+funcs
 functools
 gcda
 gcno
@@ -201,6 +204,7 @@ timebase
 toctree
 todo
 toolchain
+toolchains
 truediv
 typehints
 typename

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -1,0 +1,40 @@
+# Semantic code analysis with CodeQL 
+# see https://github.com/github/codeql-action
+name: "CodeQL Security Scan"
+
+on:
+  push:
+    branches: [ master, devel ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master, devel ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        config-file: ./.github/actions/codeql/security-pack.yml
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| Github Actions |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds a Github Actions workflow that runs the security and quality static code analysis in order to phase LGTM out.

## Rationale

[lgtm.com](https://github.com/nasa/fprime/pull/lgtm.com) will be shut down at the end of the year.

## Future Work

Remove the LGTM configuration files once it's fully shut down.

## Comments

Results should be viewable once the checks are done. It's currently running all queries from the `security-and-quality` suite, let me know if we want to filter some categories out. 