### PR TITLE
Add a cleaner way to print comment separator lines

### DIFF
--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -463,9 +463,7 @@ def new_port(deployment: Path, build: Build):
             return 0
         regenerate(build)
         print("")
-        print(
-            "################################################################################"
-        )
+        print("#"*80)
         print("")
         print(
             "You have successfully created the port "
@@ -474,9 +472,7 @@ def new_port(deployment: Path, build: Build):
             + context["dir_name"]
         )
         print("")
-        print(
-            "################################################################################"
-        )
+        print("#"*80)
         return 0
     except OutputDirExistsException as out_directory_error:
         print(f"{out_directory_error}", file=sys.stderr)

--- a/src/fprime/fbuild/interaction.py
+++ b/src/fprime/fbuild/interaction.py
@@ -463,7 +463,7 @@ def new_port(deployment: Path, build: Build):
             return 0
         regenerate(build)
         print("")
-        print("#"*80)
+        print("#" * 80)
         print("")
         print(
             "You have successfully created the port "
@@ -472,7 +472,7 @@ def new_port(deployment: Path, build: Build):
             + context["dir_name"]
         )
         print("")
-        print("#"*80)
+        print("#" * 80)
         return 0
     except OutputDirExistsException as out_directory_error:
         print(f"{out_directory_error}", file=sys.stderr)

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -65,7 +65,7 @@ def print_info(
         print(
             f"    Available global targets: {' '.join(global_generic_targets.keys())}"
         )
-        print("  ----------------------------------------------------------")
+        print(f'{"  ":-<60}')
     # Artifact locations come afterwards
     for (
         build_type,


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| None |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR adds a cleaner way to print the comment separator lines.

## Rationale

For reasons of readability.

## Testing/Review Recommendations

None

## Future Work

None
