### PR TITLE
Add a `getMaxSize()` Method To Types

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -117,5 +117,10 @@ class ArrayType(DictionaryType):
         self._val = values
 
     def getSize(self):
-        """Return the size of the array"""
+        """Return the size in bytes of the array"""
         return sum(item.getSize() for item in self._val)
+
+    @classmethod
+    def getMaxSize(cls):
+        """Return the maximum size in bytes of the array"""
+        return cls.MEMBER_TYPE.getMaxSize() * cls.LENGTH

--- a/src/fprime/common/models/serialize/bool_type.py
+++ b/src/fprime/common/models/serialize/bool_type.py
@@ -44,5 +44,11 @@ class BoolType(ValueType):
         except struct.error:
             raise DeserializeException("Not enough bytes to deserialize bool.")
 
-    def getSize(self):
+    @classmethod
+    def getSize(cls):
         return struct.calcsize("B")
+
+    @classmethod
+    def getMaxSize(cls):
+        """ Maximum size of type """
+        return cls.getSize()  # Always the same as getSize

--- a/src/fprime/common/models/serialize/bool_type.py
+++ b/src/fprime/common/models/serialize/bool_type.py
@@ -50,5 +50,5 @@ class BoolType(ValueType):
 
     @classmethod
     def getMaxSize(cls):
-        """ Maximum size of type """
+        """Maximum size of type"""
         return cls.getSize()  # Always the same as getSize

--- a/src/fprime/common/models/serialize/enum_type.py
+++ b/src/fprime/common/models/serialize/enum_type.py
@@ -87,6 +87,12 @@ class EnumType(DictionaryType):
         else:
             raise TypeRangeException(int_val)
 
-    def getSize(self):
+    @classmethod
+    def getSize(cls):
         """Calculates the size based on the size of an integer used to store it"""
         return struct.calcsize(">i")
+
+    @classmethod
+    def getMaxSize(cls):
+        """ Maximum size of type """
+        return cls.getSize()  # Always the same as getSize

--- a/src/fprime/common/models/serialize/enum_type.py
+++ b/src/fprime/common/models/serialize/enum_type.py
@@ -94,5 +94,5 @@ class EnumType(DictionaryType):
 
     @classmethod
     def getMaxSize(cls):
-        """ Maximum size of type """
+        """Maximum size of type"""
         return cls.getSize()  # Always the same as getSize

--- a/src/fprime/common/models/serialize/numerical_types.py
+++ b/src/fprime/common/models/serialize/numerical_types.py
@@ -33,7 +33,7 @@ class NumericalType(ValueType, abc.ABC):
 
     @classmethod
     def getMaxSize(cls):
-        """ Maximum size of type """
+        """Maximum size of type"""
         return cls.getSize()  # Always the same as getSize
 
     @staticmethod

--- a/src/fprime/common/models/serialize/numerical_types.py
+++ b/src/fprime/common/models/serialize/numerical_types.py
@@ -31,6 +31,11 @@ class NumericalType(ValueType, abc.ABC):
         """Gets the size of the integer based on the size specified in the class name"""
         return int(cls.get_bits() >> 3)  # Divide by 8 quickly
 
+    @classmethod
+    def getMaxSize(cls):
+        """ Maximum size of type """
+        return cls.getSize()  # Always the same as getSize
+
     @staticmethod
     @abc.abstractmethod
     def get_serialize_format():

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -148,6 +148,11 @@ class SerializableType(DictionaryType):
         """The size of a struct is the size of all the members"""
         return sum(self._val.get(name).getSize() for name, _, _, _ in self.MEMBER_LIST)
 
+    @classmethod
+    def getMaxSize(cls):
+        """Return the maximum size in bytes of the array"""
+        return sum(member_type.getMaxSize() for _, member_type, _, _ in self.MEMBER_LIST)
+
     def to_jsonable(self):
         """
         JSONable type for a serializable

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -151,7 +151,7 @@ class SerializableType(DictionaryType):
     @classmethod
     def getMaxSize(cls):
         """Return the maximum size in bytes of the array"""
-        return sum(member_type.getMaxSize() for _, member_type, _, _ in self.MEMBER_LIST)
+        return sum(member_type.getMaxSize() for _, member_type, _, _ in cls.MEMBER_LIST)
 
     def to_jsonable(self):
         """

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -75,3 +75,8 @@ class StringType(type_base.DictionaryType):
         Get the size of this object
         """
         return struct.calcsize(">H") + len(self.val)
+
+    @classmethod
+    def getMaxSize(cls):
+        """ Get maximum size of the type """
+        return cls.MAX_LENGTH

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -78,5 +78,5 @@ class StringType(type_base.DictionaryType):
 
     @classmethod
     def getMaxSize(cls):
-        """ Get maximum size of the type """
+        """Get maximum size of the type"""
         return struct.calcsize(">H") + cls.MAX_LENGTH

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -79,4 +79,4 @@ class StringType(type_base.DictionaryType):
     @classmethod
     def getMaxSize(cls):
         """ Get maximum size of the type """
-        return cls.MAX_LENGTH
+        return struct.calcsize(">H") + cls.MAX_LENGTH

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -22,7 +22,7 @@ import math
 from enum import Enum
 
 # Custom Python Modules
-import fprime.common.models.serialize.numerical_types
+from fprime.common.models.serialize.numerical_types import U8Type, U16Type, U32Type
 from fprime.common.models.serialize import type_base
 from fprime.common.models.serialize.type_exceptions import TypeRangeException
 
@@ -82,14 +82,10 @@ class TimeType(type_base.BaseType):
         self._check_time_base(time_base)
         self._check_useconds(useconds)
 
-        self.__timeBase = fprime.common.models.serialize.numerical_types.U16Type(
-            time_base
-        )
-        self.__timeContext = fprime.common.models.serialize.numerical_types.U8Type(
-            time_context
-        )
-        self.__secs = fprime.common.models.serialize.numerical_types.U32Type(seconds)
-        self.__usecs = fprime.common.models.serialize.numerical_types.U32Type(useconds)
+        self.__timeBase = U16Type(time_base)
+        self.__timeContext = U8Type(time_context)
+        self.__secs = U32Type(seconds)
+        self.__usecs = U32Type(useconds)
 
     @staticmethod
     def _check_useconds(useconds):
@@ -209,19 +205,25 @@ class TimeType(type_base.BaseType):
         self.__usecs.deserialize(data, offset)
         offset += self.__usecs.getSize()
 
-    def getSize(self):
+    @classmethod
+    def getSize(cls):
         """
         Return the size of the time type object when serialized
 
         Returns:
             The size of the time type object when serialized
         """
-        return (
-            self.__timeBase.getSize()
-            + self.__timeContext.getSize()
-            + self.__secs.getSize()
-            + self.__usecs.getSize()
-        )
+        return U16Type.getSize() + U8Type.getSize() + U32Type.getSize() + U32Type.getSize()
+
+    @classmethod
+    def getMaxSize(cls):
+        """
+        Return the size of the time type object when serialized
+
+        Returns:
+            The size of the time type object when serialized
+        """
+        return cls.getSize()
 
     @staticmethod
     def compare(t1, t2):

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -213,7 +213,9 @@ class TimeType(type_base.BaseType):
         Returns:
             The size of the time type object when serialized
         """
-        return U16Type.getSize() + U8Type.getSize() + U32Type.getSize() + U32Type.getSize()
+        return (
+            U16Type.getSize() + U8Type.getSize() + U32Type.getSize() + U32Type.getSize()
+        )
 
     @classmethod
     def getMaxSize(cls):
@@ -332,9 +334,7 @@ class TimeType(type_base.BaseType):
         self._check_time_base(time_base)
         self._check_useconds(useconds)
 
-        self.__timeBase = U16Type(
-            time_base
-        )
+        self.__timeBase = U16Type(time_base)
         self.__secs = U32Type(seconds)
         self.__usecs = U32Type(useconds)
 

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -137,7 +137,7 @@ class TimeType(type_base.BaseType):
     @timeBase.setter
     def timeBase(self, val):
         self._check_time_base(val)
-        self.__timeBase = fprime.common.models.serialize.numerical_types.U16Type(val)
+        self.__timeBase = U16Type(val)
 
     @property
     def timeContext(self):
@@ -145,7 +145,7 @@ class TimeType(type_base.BaseType):
 
     @timeContext.setter
     def timeContext(self, val):
-        self.__timeContext = fprime.common.models.serialize.numerical_types.U8Type(val)
+        self.__timeContext = U8Type(val)
 
     @property
     def seconds(self):
@@ -153,7 +153,7 @@ class TimeType(type_base.BaseType):
 
     @seconds.setter
     def seconds(self, val):
-        self.__secs = fprime.common.models.serialize.numerical_types.U32Type(val)
+        self.__secs = U32Type(val)
 
     @property
     def useconds(self):
@@ -162,7 +162,7 @@ class TimeType(type_base.BaseType):
     @useconds.setter
     def useconds(self, val):
         self._check_useconds(val)
-        self.__usecs = fprime.common.models.serialize.numerical_types.U32Type(val)
+        self.__usecs = U32Type(val)
 
     def serialize(self):
         """
@@ -332,11 +332,11 @@ class TimeType(type_base.BaseType):
         self._check_time_base(time_base)
         self._check_useconds(useconds)
 
-        self.__timeBase = fprime.common.models.serialize.numerical_types.U16Type(
+        self.__timeBase = U16Type(
             time_base
         )
-        self.__secs = fprime.common.models.serialize.numerical_types.U32Type(seconds)
-        self.__usecs = fprime.common.models.serialize.numerical_types.U32Type(useconds)
+        self.__secs = U32Type(seconds)
+        self.__usecs = U32Type(useconds)
 
     # The following Python special methods add support for rich comparison of TimeTypes to other
     # TimeTypes and numbers.

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -225,6 +225,7 @@ class TimeType(type_base.BaseType):
         Returns:
             The size of the time type object when serialized
         """
+        # Always the same as getSize. Must be updated when time types are configurable.
         return cls.getSize()
 
     @staticmethod

--- a/src/fprime/common/models/serialize/type_base.py
+++ b/src/fprime/common/models/serialize/type_base.py
@@ -38,7 +38,7 @@ class BaseType(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def getMaxSize(cls):
-        """ Get maximum size of the type """
+        """Get maximum size of the type"""
         return AbstractMethodException("getMaxSize")
 
     def __repr__(self):

--- a/src/fprime/common/models/serialize/type_base.py
+++ b/src/fprime/common/models/serialize/type_base.py
@@ -35,8 +35,8 @@ class BaseType(abc.ABC):
         """
         raise AbstractMethodException("getSize")
 
-    @abc.abstractmethod
     @classmethod
+    @abc.abstractmethod
     def getMaxSize(cls):
         """ Get maximum size of the type """
         return AbstractMethodException("getMaxSize")

--- a/src/fprime/common/models/serialize/type_base.py
+++ b/src/fprime/common/models/serialize/type_base.py
@@ -35,6 +35,12 @@ class BaseType(abc.ABC):
         """
         raise AbstractMethodException("getSize")
 
+    @abc.abstractmethod
+    @classmethod
+    def getMaxSize(cls):
+        """ Get maximum size of the type """
+        return AbstractMethodException("getMaxSize")
+
     def __repr__(self):
         """Produces a string representation of a given type"""
         return self.__class__.__name__.replace("Type", "")

--- a/test/fprime/common/models/serialize/test_types.py
+++ b/test/fprime/common/models/serialize/test_types.py
@@ -222,10 +222,14 @@ def test_uint_types_off_nominal():
 
 def test_float_types_nominal():
     """Tests the integer types"""
-    instance = valid_values_test(F32Type, [0.31415000557899475, 0.0, -3.141590118408203], 4)
+    instance = valid_values_test(
+        F32Type, [0.31415000557899475, 0.0, -3.141590118408203], 4
+    )
     # Make sure max size is the same as the size and can be derived from the class
     assert instance.getSize() == instance.__class__.getMaxSize()
-    instance = valid_values_test(F64Type, [0.31415000557899475, 0.0, -3.141590118408203], 8)
+    instance = valid_values_test(
+        F64Type, [0.31415000557899475, 0.0, -3.141590118408203], 8
+    )
     # Make sure max size is the same as the size and can be derived from the class
     assert instance.getSize() == instance.__class__.getMaxSize()
 
@@ -276,7 +280,7 @@ def test_string_nominal():
         string_type, [py_string[:10], py_string[:4], py_string[:7]], [12, 6, 9]
     )
     # String type defined a max-size of 10 plus 2 for the size data
-    assert instance.__class__.getMaxSize() == 10+2
+    assert instance.__class__.getMaxSize() == 10 + 2
 
 
 def test_string_off_nominal():
@@ -313,12 +317,16 @@ def test_serializable_basic():
         ({"member4": "345", "member5": "abc1", "member6": 213}, 5 + 6 + 8, 12 + 6 + 8),
     ]
 
-    for index, (members, (valid, size, max_size)) in enumerate(zip(member_list, valid_values)):
+    for index, (members, (valid, size, max_size)) in enumerate(
+        zip(member_list, valid_values)
+    ):
         serializable_type = SerializableType.construct_type(
             f"BasicSerializable{index}", members
         )
         instance = valid_values_test(serializable_type, [valid], [size])
-        assert instance.__class__.getMaxSize() == max_size  # Sum of sizes of member list
+        assert (
+            instance.__class__.getMaxSize() == max_size
+        )  # Sum of sizes of member list
 
 
 def test_serializable_basic_off_nominal():
@@ -389,7 +397,9 @@ def test_serializable_advanced():
         [serializable1],
         [5 + 4 + 4 + (2 + 5 + 3) + (4 + (5 + 5 + 5))],
     )
-    assert instance.__class__.getMaxSize() == (5 + 4 + 4 + (3 * 5) + (4 +  (3 * 5)))  # Sum of sizes of member list
+    assert instance.__class__.getMaxSize() == (
+        5 + 4 + 4 + (3 * 5) + (4 + (3 * 5))
+    )  # Sum of sizes of member list
 
 
 def test_array_type():
@@ -409,7 +419,9 @@ def test_array_type():
     values = [[32, 1], [0, 1, 2, 3], ["one", "1234", "1"]]
     sizes = [8, 4, 14]
     max_sizes = [8, 4, (2 + 18) * 3]
-    for ctor_args, values, size, max_size in zip(extra_ctor_args, values, sizes, max_sizes):
+    for ctor_args, values, size, max_size in zip(
+        extra_ctor_args, values, sizes, max_sizes
+    ):
         type_input = ArrayType.construct_type(*ctor_args)
         instance = valid_values_test(type_input, [values], [size])
         assert instance.__class__.getMaxSize() == max_size


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

When looking towards packetized telemetry in F´, we need the ability to determine not just the real size of a type, but the maximum size of that type that is reserved for it in a telemetry packet.

This PR adds those methods, cleans up type importing in the TimeType, and adds UTs.