### PR TITLE
adding default cmake settings

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -401,6 +401,7 @@ class Build:
             default_cmake_args = {
                 option: value
                 for (option, value) in [split_pair(item) for item in default_options]
+                if option != ""
             }
 
             self.cmake.generate_build(

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -311,6 +311,9 @@ class Build:
             if self.get_settings(setting, None) is not None
         }
 
+        # Load in the default settings
+        self.get_settings("default_cmake_options", None)
+
         if "FPRIME_LIBRARY_LOCATIONS" in cmake_args:
             cmake_args["FPRIME_LIBRARY_LOCATIONS"] = ";".join(
                 [str(location) for location in cmake_args["FPRIME_LIBRARY_LOCATIONS"]]
@@ -387,10 +390,23 @@ class Build:
             cmake_args: cmake arguments to pass into the generate step
         """
         try:
+
+            def split_pair(item):
+                """Process an item into a two-tuple always"""
+                return tuple([*item.strip().split("=", 1), ""][:2])
+
+            default_options_text = self.get_settings("default_cmake_options", None)
+            default_options = default_options_text.split("\n")
+
+            default_cmake_args = {
+                option: value
+                for (option, value) in [split_pair(item) for item in default_options]
+            }
+
             self.cmake.generate_build(
                 self.deployment,
                 self.build_dir,
-                {**cmake_args, **self.get_cmake_args()},
+                {**default_cmake_args, **cmake_args, **self.get_cmake_args()},
                 environment=self.settings.get("environment", None),
             )
         except CMakeException as cexc:

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -10,7 +10,7 @@ import os
 import configparser
 from functools import partial
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Union, Callable, Any
 from pathlib import Path
 
 
@@ -78,6 +78,7 @@ class IniSettings:
             SettingType.PATH,
             lambda settings: settings["settings_file"],
         ),
+        ("default_cmake_options", SettingType.STRING, ""),
     ]
 
     @staticmethod
@@ -116,14 +117,17 @@ class IniSettings:
     @staticmethod
     def read_setting(
         config_parser: configparser.ConfigParser,
-        settings: dict,
+        settings: Dict[str, Any],
         section: str,
         key: str,
         settings_type: SettingType,
-        default,
+        default: Union[Callable, Any],
     ):
         """Reads an individual setting"""
-        get_default_value = lambda: default(settings) if callable(default) else default
+
+        def get_default_value():
+            """Calculates the default value for the given setting"""
+            return default(settings) if callable(default) else default
 
         if config_parser is None:
             value = get_default_value()

--- a/test/fprime/fbuild/settings-data/settings-multi-line-default-options.ini
+++ b/test/fprime/fbuild/settings-data/settings-multi-line-default-options.ini
@@ -1,0 +1,5 @@
+[fprime]
+framework_path: ../..
+default_cmake_options: OPTION1=ABC
+    OPTION2=123
+    OPTION3=Something

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -96,7 +96,7 @@ def test_get_fprime_configuration():
 def test_get_include_locations():
     """
     Test all the include locations. This will ensure that values are properly read from a cache listing. This will
-    support various other portions of the system, so debug here firest.
+    support various other portions of the system, so debug here first.
     """
     test_data = {
         "grand-unified": ["/home/user11/fprime"],

--- a/test/fprime/fbuild/test_settings.py
+++ b/test/fprime/fbuild/test_settings.py
@@ -106,6 +106,28 @@ def test_settings():
                 "default_cmake_options": "",
             },
         },
+        {
+            "file": "settings-multi-line-default-options.ini",
+            "expected": {
+                "settings_file": full_path(
+                    "settings-data/settings-multi-line-default-options.ini"
+                ),
+                "default_toolchain": "native",
+                "default_ut_toolchain": "native",
+                "framework_path": full_path(".."),
+                "install_destination": full_path("settings-data/build-artifacts"),
+                "library_locations": [],
+                "environment_file": full_path(
+                    "settings-data/settings-multi-line-default-options.ini"
+                ),
+                "environment": {},
+                "component_cookiecutter": "default",
+                "ac_constants": full_path("..") / "config" / "AcConstants.ini",
+                "project_root": full_path(".."),
+                "config_directory": full_path("..") / "config",
+                "default_cmake_options": "OPTION1=ABC\nOPTION2=123\nOPTION3=Something",
+            },
+        },
     ]
 
     for case in test_cases:

--- a/test/fprime/fbuild/test_settings.py
+++ b/test/fprime/fbuild/test_settings.py
@@ -39,6 +39,7 @@ def test_settings():
                 "ac_constants": full_path("..") / "config" / "AcConstants.ini",
                 "project_root": full_path(".."),
                 "config_directory": full_path("..") / "config",
+                "default_cmake_options": "",
             },
         },
         {
@@ -58,6 +59,7 @@ def test_settings():
                 "ac_constants": full_path("..") / "config" / "AcConstants.ini",
                 "project_root": full_path(".."),
                 "config_directory": full_path("..") / "config",
+                "default_cmake_options": "",
             },
         },
         {
@@ -79,6 +81,7 @@ def test_settings():
                 "ac_constants": full_path("..") / "config" / "AcConstants.ini",
                 "project_root": full_path(".."),
                 "config_directory": full_path("..") / "config",
+                "default_cmake_options": "",
             },
         },
         {
@@ -100,6 +103,7 @@ def test_settings():
                 "ac_constants": full_path("..") / "config" / "AcConstants.ini",
                 "project_root": full_path(".."),
                 "config_directory": full_path("..") / "config",
+                "default_cmake_options": "",
             },
         },
     ]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Enables users to set the `default_cmake_options` `settings.ini` field to pass in default cmake options.