### PR TITLE
Add sanitizer to UT compilation

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -170,6 +170,7 @@ rstrip
 rsub
 rtd
 rtruediv
+sanitizers
 Sched
 SCLK
 scm

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -51,6 +51,11 @@ def run_fbuild_cli(
         toolchain = build.find_toolchain()
         print(f"[INFO] Generating build directory at: {build.build_dir}")
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
+        if parsed.sanitize == True:
+            # The following options are defined in F' to have CMake enable the sanitizers
+            cmake_args["ENABLE_SANITIZER_LEAK"] = 'ON'
+            cmake_args["ENABLE_SANITIZER_ADDRESS"] = 'ON'
+            cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = 'ON'
         if toolchain is not None:
             cmake_args["CMAKE_TOOLCHAIN_FILE"] = toolchain
         build.generate(cmake_args)
@@ -190,6 +195,12 @@ def add_special_targets(
         help="Pass -D flags through to CMakes",
         nargs=1,
         default=[],
+    )
+    generate_parser.add_argument(
+        "--sanitize",
+        default=False,
+        help="Enable sanitizers at compilation (leak, address, undefined behavior)",
+        action="store_true",
     )
     purge_parser = subparsers.add_parser(
         "purge",

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -51,7 +51,7 @@ def run_fbuild_cli(
         toolchain = build.find_toolchain()
         print(f"[INFO] Generating build directory at: {build.build_dir}")
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
-        if parsed.sanitize == True:
+        if (parsed.ut == True and parsed.disable_sanitizers == False):
             # The following options are defined in F' to have CMake enable the sanitizers
             cmake_args["ENABLE_SANITIZER_LEAK"] = "ON"
             cmake_args["ENABLE_SANITIZER_ADDRESS"] = "ON"
@@ -190,17 +190,17 @@ def add_special_targets(
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     generate_parser.add_argument(
+        "--disable-sanitizers",
+        default=False,
+        help="Disable the compiler sanitizers. Sanitizers are only enabled by default when --ut is provided.",
+        action="store_true",
+    )
+    generate_parser.add_argument(
         "-Dxyz",
         action="append",
         help="Pass -D flags through to CMakes",
         nargs=1,
         default=[],
-    )
-    generate_parser.add_argument(
-        "--sanitize",
-        default=False,
-        help="Enable sanitizers at compilation (leak, address, undefined behavior)",
-        action="store_true",
     )
     purge_parser = subparsers.add_parser(
         "purge",

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -53,9 +53,9 @@ def run_fbuild_cli(
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
         if parsed.sanitize == True:
             # The following options are defined in F' to have CMake enable the sanitizers
-            cmake_args["ENABLE_SANITIZER_LEAK"] = 'ON'
-            cmake_args["ENABLE_SANITIZER_ADDRESS"] = 'ON'
-            cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = 'ON'
+            cmake_args["ENABLE_SANITIZER_LEAK"] = "ON"
+            cmake_args["ENABLE_SANITIZER_ADDRESS"] = "ON"
+            cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = "ON"
         if toolchain is not None:
             cmake_args["CMAKE_TOOLCHAIN_FILE"] = toolchain
         build.generate(cmake_args)

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -51,7 +51,7 @@ def run_fbuild_cli(
         toolchain = build.find_toolchain()
         print(f"[INFO] Generating build directory at: {build.build_dir}")
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
-        if (parsed.ut == True and parsed.disable_sanitizers == False):
+        if parsed.ut == True and parsed.disable_sanitizers == False:
             # The following options are defined in F' to have CMake enable the sanitizers
             cmake_args["ENABLE_SANITIZER_LEAK"] = "ON"
             cmake_args["ENABLE_SANITIZER_ADDRESS"] = "ON"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| `fprime-util generate` |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/pull/1772 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Following https://github.com/nasa/fprime/pull/1772, this adds the compiler sanitizers by default on `--ut` targets. An option is added (`fprime-util generate --ut --disable-sanitizers`) in order to disable the sanitizers if needed.

This enables the **leak**, **memory** and **undefined behavior** sanitizers at compilation by passing the associated flags down to CMake. Note that leak is not available on macOS, but this is handled by CMake down at the fprime level (cmake will refuse to activate LSAN on macOS).



