### PR TITLE
Remove upper bounds on dependency requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,17 +81,17 @@ to interact with the data coming from the FSW.
     # Requires Python 3.7+
     python_requires=">=3.7",
     install_requires=[
-        "lxml>=4.6.3, <5.0.0",
-        "Markdown>=3.3.4, <4.0.0",
-        "pexpect>=4.8.0, <5.0.0",
-        "pytest>=6.2.4, <7.0.0",
-        "Cheetah3>=3.2.6, <4.0.0",
-        "cookiecutter>=1.7.2, <2.0.0",
-        "gcovr>=5.0, <6.0",
+        "lxml>=4.6.3",
+        "Markdown>=3.3.4",
+        "pexpect>=4.8.0",
+        "pytest>=6.2.4",
+        "Cheetah3>=3.2.6",
+        "cookiecutter>=1.7.2",
+        "gcovr>=5.0",
     ],
     extras_require={
         "dev": [
-            "black==21.5b1",
+            "black",
             "pylama",
             "pylint",
             "pre-commit",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| `setup.py` |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1690 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removing the upper bounds on dependency requirements in the `setup.py` in preparation for version bumps in F' core requirements.txt

## Rationale

Python package versions need bumping as some are insecure. This will be done in the requirements.txt in F', but we need to loosen the requirements on fprime-tools as there are upper bounds. I chose to remove the upper bounds altogether for the following reasons:
- the usage of upper bounds is most often based on the presumption that future major versions will break untested code - a presumption that is usually incorrect 
- there is really no reason to install fprime-tools by itself, so the dependency versions are controlled by fprime's requirements.txt anyways
- makes future updates easier

The only downside of this approach that I could identify is that there is a very small probability that by installing an external dependency in the virtual environment, that dependency will introduce an upgrade of one of fprime's dependency - and that upgrade _might_ break things... 
Let me know what you think
