### PR TITLE
Remove requirement on 'format' to have a valid build cache

### DIFF
--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -242,7 +242,7 @@ def utility_entry(args):
         # However, the base directory must be setup here. Errors in this load are ignored to allow the command to find
         # build caches related to that set.
         try:
-            if parsed.command == "generate":
+            if parsed.command == "generate" or parsed.command == "format":
                 build.invent(parsed.platform, build_dir=parsed.build_cache)
             else:
                 build.load(parsed.platform, parsed.build_cache)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes nasa/fprime#1890