### PR TITLE
Add Python 3.11 to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install --upgrade pip urllib3 setuptools_scm
       - name: clone fprime and gps-tutorial
         run: |
-          git clone -b ${{ matrix.fprime-version[0] }} https://github.com/nasa/fprime.git
+          git clone -b ${{ matrix.fprime-version }} https://github.com/nasa/fprime.git
           git clone --recurse-submodules https://github.com/fprime-community/gps-tutorial.git
           pip install -r fprime/requirements.txt || true # Attempt to install fprime package when available
       - name: Generate correct fprime version in gps-tutorial

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        fprime-version: [[NASA-v1.5.3, 99cef07], [v2.0.0, 521516c], [v3.0.0, 521516c], [devel, 521516c]]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        fprime-version: ["NASA-v1.5.3", "v2.0.0", "v3.0.0", "devel"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         fprime-version: ["NASA-v1.5.3", "v2.0.0", "v3.0.0", "devel"]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding Python 3.11 to the integration test workflow. 
I also set the `strategy.fail-fast` to false. Default was True which caused all integration tests to abort if one failed, which can give a wrong impression of what's happening and take longer to review. That way, we know which ones are failing and which ones are not, without having to dig through the logs.
I also removed some unused variables that were probably copy/pasted from somewhere else, as it doesn't look like they were ever used.
