### PR TITLE
Handle whitespaces in `format` command

### DIFF
--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -97,9 +97,9 @@ class ClangFormatter(ExecutableAction):
             with open(filepath, "r") as file:
                 content = file.read()
             # Replace the strings in the file content
-            content = re.sub("PROTECTED:", PROTECTED_PRE_PATTERN, content)
-            content = re.sub("PRIVATE:", PRIVATE_PRE_PATTERN, content)
-            content = re.sub("STATIC:", STATIC_PRE_PATTERN, content)
+            content = re.sub("PROTECTED[\s]*:", PROTECTED_PRE_PATTERN, content)
+            content = re.sub("PRIVATE[\s]*:", PRIVATE_PRE_PATTERN, content)
+            content = re.sub("STATIC[\s]*:", STATIC_PRE_PATTERN, content)
             # Write the file out to the same location, seemingly in-place
             with open(filepath, "w") as file:
                 file.write(content)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| `format` |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1939 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Handles whitespaces in between FPrime access modifiers and the colon, such as `PRIVATE:`. This will also catch newlines, so patterns like 
```
PRIVATE
:
```
which are technically correct are handled and formatted correctly.

**Note:** the output of the formatting tool is not being altered. That is, a `PRIVATE   :` input will result in a `PRIVATE:` output, which is the correct formatting.

## Rationale

Fixes https://github.com/nasa/fprime/issues/1939
