### PR TITLE
fixing gcovr usage for -p and -d flags

### DIFF
--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -1,5 +1,6 @@
 """ fprime.fbuild.gcovr: coverage target implementations """
 import atexit
+import itertools
 import shutil
 import subprocess
 import sys
@@ -7,8 +8,6 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
 from .target import ExecutableAction, Target, TargetScope, CompositeTarget
-
-TEMPORARY_DIRECTORY = "{{AUTOCODE}}"
 
 
 def _get_project_path(builder: "Build", module: Union[str, Path]) -> Path:
@@ -36,24 +35,6 @@ def _using_root(builder: "Build", context: Path, scope: TargetScope):
     return builder.is_deployment(context) or scope == TargetScope.GLOBAL
 
 
-def _get_ac_directory(builder: "Build", context: Path, scope: TargetScope) -> Path:
-    """Gets a directory for AC files to be placed
-
-    AC files need to migrate out of the build cache and into the build for purposes of HTML coverage.  This selects an
-    appropriate location for this temporary directory.
-
-    Args:
-        builder: build to use
-        context: path context to use
-    """
-    base_path = (
-        _get_project_path(builder, ".")
-        if _using_root(builder, context, scope)
-        else context
-    )
-    return (base_path / TEMPORARY_DIRECTORY).absolute()
-
-
 class GcovClean(ExecutableAction):
     """Target used to scrub gcov files before a coverage run
 
@@ -65,7 +46,10 @@ class GcovClean(ExecutableAction):
     REMOVAL_EXTENSIONS = [".gcda"]
 
     def execute(
-        self, builder: "Build", context: Path, args: Tuple[Dict[str, str], List[str]]
+        self,
+        builder: "Build",
+        context: Path,
+        args: Tuple[Dict[str, str], List[str], Dict[str, bool]],
     ):
         """Execute the clean using os.walk"""
         print(f"[INFO] Scrubbing leftover { ', '.join(self.REMOVAL_EXTENSIONS)} files")
@@ -79,117 +63,6 @@ class GcovClean(ExecutableAction):
                 path.unlink()
             elif path.is_dir():
                 cls._recurse(path)
-
-
-class GcovrAcHelper(ExecutableAction):
-    """Helps with AC file paths and gcovr reports
-
-    Autocoded files are created in the build cache, but not in the same directory as the .gcda and .gcno files. This
-    causes the --html-details flag to fail to find these files when generating the detailed HTML w/ source output. This
-    action will fix this by coping these files to a known working directory to work within.
-
-    Specifically:
-    - Create temporary directory
-    - Register an at_exit handler to clean-up the directory
-    - For each .gcda file in build cache:
-    -   Copy matching .cpp and .hpp file from two parent directories above to temporary directory
-    """
-
-    EXTENSION_TRIGGER = [".gcno", ".gcda"]
-
-    def __init__(self, scope: TargetScope):
-        """Init function"""
-        super().__init__(scope)
-        self.collided_files = set()
-
-    def execute(
-        self, builder: "Build", context: Path, args: Tuple[Dict[str, str], List[str]]
-    ):
-        """Execute this action"""
-        temp_path = _get_ac_directory(builder, context, self.scope)
-        print(f"[INFO] Making temporary directory: {temp_path}")
-        temp_path.mkdir(exist_ok=False)
-        atexit.register(self.removal, temp_path)
-        print("[INFO] Copying AC files into temporary directory")
-        cache_path = builder.build_dir / builder.get_build_cache_path(context)
-        recurse_path = (
-            Path(builder.build_dir)
-            if _using_root(builder, context, self.scope)
-            else cache_path
-        )
-        # Recurse excluding the autocoders directory which is filled with test codes
-        self._recurse(
-            recurse_path,
-            temp_path,
-            [(builder.build_dir / "F-Prime" / "Autocoders").absolute()],
-        )
-        for item in list(self.collided_files):
-            print(f"[WARNING] Removing contested file: {item.name}")
-            item.unlink()
-
-    def copy_safe(self, source: Path, destination: Path):
-        """Copy one file if it doesn't exist. Checking content if it does.
-
-        Copy if the destination does not exist. If the content differs, add the offending file to a list to clean up
-        later such that it cannot explode gcovr. Deferring removal prevents a third copy from winning.
-
-        Args:
-            source: source file
-            destination: destination file
-        """
-        if not destination.exists():
-            shutil.copy(source, destination)
-            return
-        with open(source) as file1:
-            lines1 = file1.readlines()
-        with open(destination) as file2:
-            lines2 = file2.readlines()
-        # Line number deltas are known to cause problems as gcovr becomes unhappy when the line number becomes
-        # inconsistent with the source it is reading.
-        if len(lines1) != len(lines2):
-            self.collided_files.add(destination)
-            return
-        for line1, line2 in zip(lines1, lines2):
-            # Lines that that match and lines that differ only by the include statement are ok. These are the models
-            # that implement multiple physical components.
-            if (line1.strip() == line2.strip()) or (
-                line1.strip().startswith("#include")
-                and line2.strip().startswith("#include")
-            ):
-                continue
-            # Real differences count as collisions
-            self.collided_files.add(destination)
-
-    @staticmethod
-    def removal(directory: Path):
-        """Function to remove temporary directory"""
-        print(f"[INFO] Removing temporary directory: {directory}")
-        shutil.rmtree(directory)
-
-    def copy_gcda_pair(self, destination: Path, gcda: Path):
-        """Copy matching CPP and HPP files given an .gcda"""
-        base_name = gcda.name
-        for extension in self.EXTENSION_TRIGGER:
-            base_name = base_name.replace(extension, "")
-        ac_folder = gcda.parent.parent.parent
-
-        # Copy both possible AC files into the destination folder
-        for possible in [base_name, base_name.replace(".cpp", ".hpp")]:
-            source = ac_folder / possible
-            if source.exists():
-                self.copy_safe(source, destination / possible)
-
-    def _recurse(self, parent_path: Path, destination: Path, excludes: List[Path]):
-        """Recursive helper"""
-        for path in parent_path.iterdir():
-            if path.absolute() in excludes:
-                continue
-            if path.is_file() and path.suffix in self.EXTENSION_TRIGGER:
-                self.copy_gcda_pair(destination, path)
-            elif path.is_file() and path.name.endswith("Ac.hpp"):
-                self.copy_safe(path, destination / path.name)
-            elif path.is_dir():
-                self._recurse(path, destination, excludes)
 
 
 class Gcovr(ExecutableAction):
@@ -218,7 +91,10 @@ class Gcovr(ExecutableAction):
         return bool(shutil.which(self.EXECUTABLE))
 
     def execute(
-        self, builder: "Build", context: Path, args: Tuple[Dict[str, str], List[str]]
+        self,
+        builder: "Build",
+        context: Path,
+        args: Tuple[Dict[str, str], List[str], Dict[str, bool]],
     ):
         """Executes the gcovr target"""
         if not shutil.which(self.EXECUTABLE):
@@ -227,60 +103,108 @@ class Gcovr(ExecutableAction):
                 file=sys.stderr,
             )
             return
-        ac_temporary_path = _get_ac_directory(builder, context, self.scope)
-        coverage_output_dir = context / "coverage"
+        build_cache_resolved = Path(builder.build_dir).absolute().resolve()
+
+        _, pass_through_args, options = args
+        include_all_ac = options["--all-ac"]
+        include_comp_ac = include_all_ac or options["--comp-ac"]
+        include_port_ac = include_all_ac or options["--port-ac"]
+        include_type_ac = include_all_ac or options["--type-ac"]
+
+        exclusion_filter_bases = [
+            None if include_comp_ac else ".*ComponentAc.[ch]pp",
+            None if include_port_ac else ".*PortAc.[ch]pp",
+            None if include_type_ac else ".*SerializableAc.[ch]pp",
+            None if include_type_ac else ".*ArrayAc.[ch]pp",
+            None if include_type_ac else ".*EnumAc.[ch]pp",
+        ]
+        exclusion_filter_bases = filter(
+            lambda item: item is not None, exclusion_filter_bases
+        )
+        exclusion_filter_bases = [
+            ["--exclude", f"{build_cache_resolved}/{exclusion}"]
+            for exclusion in exclusion_filter_bases
+        ]
+
+        build_cache_path = (
+            (
+                builder.build_dir
+                if _using_root(builder, context, self.scope)
+                else builder.get_build_cache_path(context)
+            )
+            .absolute()
+            .resolve()
+        )
+
+        coverage_output_dir = context.absolute().resolve() / "coverage"
         coverage_output_dir.mkdir(exist_ok=True)
-        project_root = builder.get_settings(
-            "project_root",
-            builder.get_settings("framework_path", builder.build_dir.parent.parent),
+        project_root = (
+            builder.get_settings(
+                "project_root",
+                builder.get_settings("framework_path", builder.build_dir.parent.parent),
+            )
+            .absolute()
+            .resolve()
         )
         filter_path = (
-            Path(project_root).absolute()
-            if _using_root(builder, context, self.scope)
-            else _get_project_path(builder, context)
+            (
+                Path(project_root).absolute()
+                if _using_root(builder, context, self.scope)
+                else _get_project_path(builder, context)
+            )
+            .absolute()
+            .resolve()
         )
-        build_offset = (
-            ""
-            if _using_root(builder, context, self.scope)
-            else builder.get_build_cache_path(context)
+        exclude_autocoders = (
+            builder.get_settings("framework_path", builder.build_dir.parent.parent)
+            / "Autocoders"
+        )
+        exclude_gtest = (
+            builder.get_settings("framework_path", builder.build_dir.parent.parent)
+            / "gtest"
         )
 
-        # gcovr is an unhappy beast (but it is *much* better than the raw gcov executable
-        # In order to deal with gcovr, we need to do the following things:
-        #   1. Setup the project root (deals with relative file paths within project). This is set to our project_root.
-        #   2. Next setup the search path for object files. This is set to the build cache or build module directory.
-        #   3. Specify two filters: project_path (module directory) and autocode temp directory
-        #   4. Exclude the build cache, and autocoders
-        #   5. Then supply default output options
-        #   6. Then supply pass through arguments
-        cli_args = [
-            "gcovr",
-            "-r",
-            str(project_root),
-            builder.build_dir / build_offset,  # For efficiency in searching on modules
-            "--filter",
-            f"{filter_path}/*",
-            "--filter",
-            f"{ac_temporary_path}",
-            "--exclude",
-            str(builder.build_dir),
-            "--exclude",
-            str(
-                builder.get_settings("framework_path", builder.build_dir.parent.parent)
-                / "Autocoders"
-            ),
-            "--print-summary",
-            "--txt",
-            f"{coverage_output_dir}/summary.txt",
-            "--html-details",
-            f"{coverage_output_dir}/coverage{'-all' if self.scope == TargetScope.GLOBAL else ''}.html",
-        ]
-        cli_args.extend(args[1])
+        # gcovr is an unhappy beast
+        cli_args = (
+            [
+                "gcovr",
+                "-r",
+                str(project_root),
+                str(build_cache_path),  # For efficiency in searching on modules
+            ]
+            + list(itertools.chain.from_iterable(exclusion_filter_bases))
+            + [
+                "--exclude",
+                f"{exclude_autocoders}",
+                "--exclude",
+                f"{exclude_gtest}",
+                "--filter",
+                f"{filter_path}",
+                "--filter",
+                f"{build_cache_path}",
+                "--print-summary",
+                "--txt",
+                f"{coverage_output_dir}/summary.txt",
+                "--html-details",
+                f"{coverage_output_dir}/coverage{'-all' if self.scope == TargetScope.GLOBAL else ''}.html",
+            ]
+        )
+        cli_args.extend(pass_through_args)
 
         if builder.cmake.verbose:
-            print(f"[INFO] Running '{' '.join(cli_args)}'")
+            joined_args = " ".join(cli_args)
+            print(f'[INFO] Running "{ joined_args }"')
         # gcovr must run in the ac_temporary_path or html details cannot find the Ac files
-        subprocess.call(cli_args, cwd=str(ac_temporary_path))
+        subprocess.call(cli_args)
+
+    def option_args(self):
+        """Option arguments"""
+        return [
+            ("--all-ac", "[coverage only] Include all autocode in coverage"),
+            ("--comp-ac", "[coverage only] Include component autocode in coverage"),
+            ("--port-ac", "[coverage only] Include port autocode in coverage"),
+            ("--type-ac", "[coverage only] Include data type autocode in coverage"),
+        ]
 
     def allows_pass_args(self):
         """Gcovr allows pass-through arguments"""
@@ -294,7 +218,7 @@ class Gcovr(ExecutableAction):
 class GcovrTarget(CompositeTarget):
     """Target specific to gcovr
 
-    The gcovr target is a composite target that builds upon an existing check target to perform gcovr work. In addition
+    The gcovr target is a composite target that builds upon an existing check target to perform gcovr work. In addition,
     it must support extra arguments as we pass these to the gcovr executable.
     """
 
@@ -305,7 +229,7 @@ class GcovrTarget(CompositeTarget):
             TargetScope.BOTH,
         ], "Cannot create composite target from incompatible target"
         super().__init__(
-            [GcovClean(scope), check_target, GcovrAcHelper(scope), Gcovr(scope)],
+            [GcovClean(scope), check_target, Gcovr(scope)],
             scope=scope,
             *args,
             **kwargs,

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -103,7 +103,7 @@ class Gcovr(ExecutableAction):
                 file=sys.stderr,
             )
             return
-        build_cache_resolved = Path(builder.build_dir).absolute().resolve()
+        build_cache_resolved = Path(builder.build_dir).resolve()
 
         _, pass_through_args, options = args
         include_all_ac = options["--all-ac"]
@@ -127,34 +127,22 @@ class Gcovr(ExecutableAction):
         ]
 
         build_cache_path = (
-            (
-                builder.build_dir
-                if _using_root(builder, context, self.scope)
-                else builder.get_build_cache_path(context)
-            )
-            .absolute()
-            .resolve()
-        )
+            builder.build_dir
+            if _using_root(builder, context, self.scope)
+            else builder.get_build_cache_path(context)
+        ).resolve()
 
-        coverage_output_dir = context.absolute().resolve() / "coverage"
+        coverage_output_dir = context.resolve() / "coverage"
         coverage_output_dir.mkdir(exist_ok=True)
-        project_root = (
-            builder.get_settings(
-                "project_root",
-                builder.get_settings("framework_path", builder.build_dir.parent.parent),
-            )
-            .absolute()
-            .resolve()
-        )
+        project_root = builder.get_settings(
+            "project_root",
+            builder.get_settings("framework_path", builder.build_dir.parent.parent),
+        ).resolve()
         filter_path = (
-            (
-                Path(project_root).absolute()
-                if _using_root(builder, context, self.scope)
-                else _get_project_path(builder, context)
-            )
-            .absolute()
-            .resolve()
-        )
+            Path(project_root).resolve()
+            if _using_root(builder, context, self.scope)
+            else _get_project_path(builder, context)
+        ).resolve()
         exclude_autocoders = (
             builder.get_settings("framework_path", builder.build_dir.parent.parent)
             / "Autocoders"

--- a/src/fprime/fbuild/target.py
+++ b/src/fprime/fbuild/target.py
@@ -64,8 +64,19 @@ class ExecutableAction(ABC):
     ):
         """Executes the given target"""
 
-    def option_args(self):
-        """List of option arguments handled by this target"""
+    def option_args(self) -> List[Tuple[str, str]]:
+        """List of option arguments handled by this target
+
+        Option flags are switches that are not allowed arguments. The current design defaults the value to False unless
+        the switch is supplied. This function is expected to return a list of pairs of switch flag and description help
+        text. e.g.
+        [
+            (--turn-on, "Turns on a switch"),
+        ]
+
+        Returns:
+            list of tuples containing the paired flag and description
+        """
         return []
 
     def allows_pass_args(self):

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -269,5 +269,6 @@ def utility_entry(args):
         return 1
     except Exception as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
+        raise
         return 1
     return 0 if status is None else status

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -269,6 +269,5 @@ def utility_entry(args):
         return 1
     except Exception as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
-        raise
         return 1
     return 0 if status is None else status


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Changes gcov handling:
1. Improves autocoding to allow including via flags: --all-ac, --comp-ac, --port-ac, --type-ac to include each of the types of Ac
2. Removes the special ac directory called `{{AUTOCODE}}`. Modern gcovr doesn't support it and it was a maintenance nightmare
3. Fixed handling of `-d` and `-p` flags