### PR TITLE
Removing author in `new --deployment`

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "deployment_name": "MyDeployment",
     "path_to_fprime": "./fprime",
-    "author_name": "",    
     "__deployment_name_upper": "{{cookiecutter.deployment_name.upper()}}"
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
@@ -1,6 +1,5 @@
 // ======================================================================
 // \title  Main.cpp
-// \author {{cookiecutter.author_name}}
 // \brief main program for the F' application. Intended for CLI-based systems (Linux, macOS)
 //
 // ======================================================================

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -1,6 +1,5 @@
 // ======================================================================
 // \title  {{cookiecutter.deployment_name}}Topology.cpp
-// \author {{cookiecutter.author_name}}
 // \brief cpp file containing the topology instantiation code
 //
 // ======================================================================

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
@@ -1,6 +1,5 @@
 // ======================================================================
 // \title  {{cookiecutter.deployment_name}}Topology.hpp
-// \author {{cookiecutter.author_name}}
 // \brief header file containing the topology instantiation definitions
 //
 // ======================================================================

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
@@ -1,6 +1,5 @@
 // ======================================================================
 // \title  {{cookiecutter.deployment_name}}TopologyDefs.hpp
-// \author {{cookiecutter.author_name}}
 // \brief required header file containing the required definitions for the topology autocoder
 //
 // ======================================================================


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removing `author_name` from cookiecutter options as it provides very little value
