### PR TITLE
Fixing python executable when only python3 exists

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -9,7 +9,7 @@ It does the following:
 
 @author thomas-bc
 """
-
+import sys
 import subprocess
 
 DEFAULT_BRANCH = "devel"
@@ -45,7 +45,7 @@ else:
 
 # Install venv if requested
 if "{{cookiecutter.install_venv}}" == "yes":
-    subprocess.run(["python", "-m", "venv", "{{cookiecutter.venv_install_path}}"])
+    subprocess.run([sys.executable, "-m", "venv", "{{cookiecutter.venv_install_path}}"])
     subprocess.run(
         [
             "{{cookiecutter.venv_install_path}}/bin/pip",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

`fprime-util new --project` calls `python` directly and does not use the `sys.executable` reference to the executable.  Thus on systems where `python3` exists but not `python` the above call will break.

This PR switches that use to `sys.executable` to ensure a valid python will always be used.