### PR TITLE
Add flags to include unit test files in coverage

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -223,6 +223,7 @@ stderr
 stdin
 stdint
 stdout
+STest
 strftime
 stylesheet
 subdir

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ to interact with the data coming from the FSW.
         "pytest>=6.2.4",
         "Cheetah3>=3.2.6",
         "cookiecutter>=1.7.2",
-        "gcovr>=5.0",
+        "gcovr>=6.0",
     ],
     extras_require={
         "dev": [

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -160,7 +160,9 @@ class Gcovr(ExecutableAction):
             if _using_root(builder, context, self.scope)
             else _get_project_path(builder, context)
         ).resolve()
-        framework_path = builder.get_settings("framework_path", builder.build_dir.parent.parent)
+        framework_path = builder.get_settings(
+            "framework_path", builder.build_dir.parent.parent
+        )
         # gcovr is an unhappy beast
         cli_args = (
             [
@@ -192,7 +194,7 @@ class Gcovr(ExecutableAction):
 
         if builder.cmake.verbose:
             joined_args = "' '".join(cli_args)
-            print(f'[INFO] Running "\'{ joined_args }\'"')
+            print(f"[INFO] Running \"'{ joined_args }'\"")
         # gcovr must run in the ac_temporary_path or html details cannot find the Ac files
         subprocess.call(cli_args)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Previous implementations did not allow for including test and autocoded test files in the coverage calculations.  This completes the set.  `--all-ac` is now `--all-sources` as it includes *everything*.