### PR TITLE
Add `flake8-error-message` convention

### DIFF
--- a/src/fprime/common/models/serialize/enum_type.py
+++ b/src/fprime/common/models/serialize/enum_type.py
@@ -77,9 +77,7 @@ class EnumType(DictionaryType):
             int_val = struct.unpack_from(">i", data, offset)[0]
         except struct.error:
             msg = f"Could not deserialize enum value. Needed: {self.getSize()} bytes Found: {len(data[offset:])}"
-            raise DeserializeException(
-                msg
-            )
+            raise DeserializeException(msg)
         for key, val in self.ENUM_DICT.items():
             if int_val == val:
                 self._val = key

--- a/src/fprime/common/models/serialize/enum_type.py
+++ b/src/fprime/common/models/serialize/enum_type.py
@@ -76,8 +76,9 @@ class EnumType(DictionaryType):
         try:
             int_val = struct.unpack_from(">i", data, offset)[0]
         except struct.error:
+            msg = f"Could not deserialize enum value. Needed: {self.getSize()} bytes Found: {len(data[offset:])}"
             raise DeserializeException(
-                f"Could not deserialize enum value. Needed: {self.getSize()} bytes Found: {len(data[offset:])}"
+                msg
             )
         for key, val in self.ENUM_DICT.items():
             if int_val == val:

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -60,8 +60,9 @@ class StringType(type_base.DictionaryType):
             val_size = struct.unpack_from(">H", data, offset)[0]
             # Deal with not enough data left in the buffer
             if len(data[offset + 2 :]) < val_size:
+                msg = f"Not enough data to deserialize string data. Needed: {val_size} Left: {len(data[offset + 2:])}"
                 raise DeserializeException(
-                    f"Not enough data to deserialize string data. Needed: {val_size} Left: {len(data[offset + 2 :])}"
+                    msg
                 )
             # Deal with a string that is larger than max string
             if self.MAX_LENGTH is not None and val_size > self.MAX_LENGTH:

--- a/src/fprime/common/models/serialize/string_type.py
+++ b/src/fprime/common/models/serialize/string_type.py
@@ -61,9 +61,7 @@ class StringType(type_base.DictionaryType):
             # Deal with not enough data left in the buffer
             if len(data[offset + 2 :]) < val_size:
                 msg = f"Not enough data to deserialize string data. Needed: {val_size} Left: {len(data[offset + 2:])}"
-                raise DeserializeException(
-                    msg
-                )
+                raise DeserializeException(msg)
             # Deal with a string that is larger than max string
             if self.MAX_LENGTH is not None and val_size > self.MAX_LENGTH:
                 raise StringSizeException(val_size, self.MAX_LENGTH)

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -312,7 +312,6 @@ class TimeType(type_base.BaseType):
         dt = None
 
         if tb in [TimeBase["TB_WORKSTATION_TIME"], TimeBase["TB_SC_TIME"]]:
-
             # This finds the local time corresponding to the timestamp and
             # timezone object, or local time zone if tz=None
             dt = datetime.datetime.fromtimestamp(self.__secs.val, tz)

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/pre_gen_project.py
@@ -1,5 +1,6 @@
 from fprime.util.cookiecutter_wrapper import is_valid_name
 
+
 # Check to ensure Component Name is valid
 def verify_inputs(component_name, commands, events, telemetry, parameters):
     if is_valid_name(component_name) != "valid":

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -90,7 +90,8 @@ class Build:
         """
         self.__setup_default(platform, build_dir)
         if self.build_dir.exists():
-            raise InvalidBuildCacheException(f"{self.build_dir} already exists.")
+            msg = f"{self.build_dir} already exists."
+            raise InvalidBuildCacheException(msg)
 
     def load(self, platform: str = None, build_dir: Path = None, skip_validation=False):
         """Load an existing build cache
@@ -124,8 +125,9 @@ class Build:
                     and platform != "default"
                     else ""
                 )
+            msg = f"'{self.build_dir}' is not a valid build cache. Generate this build cache with 'fprime-util generate{gen_args} ...'"
             raise InvalidBuildCacheException(
-                f"'{self.build_dir}' is not a valid build cache. Generate this build cache with 'fprime-util generate{gen_args} ...'",
+                msg,
                 self.build_dir,
             )
 
@@ -165,8 +167,9 @@ class Build:
         """
         hashes_file = self.build_dir / "hashes.txt"
         if not hashes_file.exists():
+            msg = f"Failed to find {hashes_file}, was the build generated?"
             raise InvalidBuildCacheException(
-                f"Failed to find {hashes_file}, was the build generated?",
+                msg,
                 self.build_dir,
             )
         with open(hashes_file) as file_handle:
@@ -280,12 +283,14 @@ class Build:
             }
         )
         if not toolchains:
+            msg = f"Could not find toolchain file for {self.platform} at any of: {' '.join(toolchains_paths)}"
             raise NoSuchToolchainException(
-                f'Could not find toolchain file for {self.platform} at any of: {" ".join(toolchains_paths)}'
+                msg
             )
         if len(toolchains) > 1:
+            msg = f"Found conflicting toolchain files for {self.platform} at: {' '.join(toolchains)}"
             raise AmbiguousToolchainException(
-                f'Found conflicting toolchain files for {self.platform} at: {" ".join(toolchains)}'
+                msg
             )
         return toolchains[0]
 
@@ -350,7 +355,8 @@ class Build:
             possible_path = self.build_dir / possible / project_relative_path
             if possible_path.exists():
                 return possible_path
-        raise MissingBuildCachePath(f"{context} has no associated build cache path")
+        msg = f"{context} has no associated build cache path"
+        raise MissingBuildCachePath(msg)
 
     def get_relative_path(self, path: Path) -> Path:
         """Gets path relative to project"""

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -284,14 +284,10 @@ class Build:
         )
         if not toolchains:
             msg = f"Could not find toolchain file for {self.platform} at any of: {' '.join(toolchains_paths)}"
-            raise NoSuchToolchainException(
-                msg
-            )
+            raise NoSuchToolchainException(msg)
         if len(toolchains) > 1:
             msg = f"Found conflicting toolchain files for {self.platform} at: {' '.join(toolchains)}"
-            raise AmbiguousToolchainException(
-                msg
-            )
+            raise AmbiguousToolchainException(msg)
         return toolchains[0]
 
     def get_cmake_args(self) -> dict:

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -509,8 +509,9 @@ class CMakeHandler:
         # Raising an exception when the return code is non-zero allows us to handle the exception internally if it is
         # needed. Thus we do not just exit.
         if ret != 0:
+            msg = f"CMake erred with return code {proc.returncode}"
             raise CMakeExecutionException(
-                f"CMake erred with return code {proc.returncode}",
+                msg,
                 stderr,
                 print_output,
                 ret,

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -109,9 +109,7 @@ class IniSettings:
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):
                 msg = f"Nonexistent path '{path}' found in section '{section}' option '{key}' of file '{ini_file}'"
-                raise FprimeSettingsException(
-                    msg
-                )
+                raise FprimeSettingsException(msg)
             expanded.append(Path(full_path).resolve())
         return expanded
 

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -108,8 +108,9 @@ class IniSettings:
                 continue
             full_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, path)))
             if exists and not os.path.exists(full_path):
+                msg = f"Nonexistent path '{path}' found in section '{section}' option '{key}' of file '{ini_file}'"
                 raise FprimeSettingsException(
-                    f"Nonexistent path '{path}' found in section '{section}' option '{key}' of file '{ini_file}'"
+                    msg
                 )
             expanded.append(Path(full_path).resolve())
         return expanded

--- a/src/fprime/fbuild/target.py
+++ b/src/fprime/fbuild/target.py
@@ -215,8 +215,9 @@ class Target(ExecutableAction):
             if target.mnemonic == mnemonic and flags == target.flags
         ]
         if not matching:
+            msg = f"Could not find target '{cls.config_string(mnemonic, flags)}'"
             raise NoSuchTargetException(
-                f"Could not find target '{cls.config_string(mnemonic, flags)}'"
+                msg
             )
         assert len(matching) == 1, "Conflicting targets specified in code"
         return matching[0]

--- a/src/fprime/fbuild/target.py
+++ b/src/fprime/fbuild/target.py
@@ -216,9 +216,7 @@ class Target(ExecutableAction):
         ]
         if not matching:
             msg = f"Could not find target '{cls.config_string(mnemonic, flags)}'"
-            raise NoSuchTargetException(
-                msg
-            )
+            raise NoSuchTargetException(msg)
         assert len(matching) == 1, "Conflicting targets specified in code"
         return matching[0]
 

--- a/src/fprime/fbuild/types.py
+++ b/src/fprime/fbuild/types.py
@@ -57,7 +57,8 @@ class BuildType(Enum):
             return ""
         if self == BuildType.BUILD_TESTING:
             return "-ut"
-        raise InvalidBuildTypeException(f"{self.name} is not a supported build type")
+        msg = f"{self.name} is not a supported build type"
+        raise InvalidBuildTypeException(msg)
 
     def get_cmake_build_type(self):
         """Get the suffix of a directory supporting this build"""
@@ -69,7 +70,8 @@ class BuildType(Enum):
             return "Release"
         if self == BuildType.BUILD_CUSTOM:
             return "Custom"
-        raise InvalidBuildTypeException(f"{self.name} is not a supported build type")
+        msg = f"{self.name} is not a supported build type"
+        raise InvalidBuildTypeException(msg)
 
     @staticmethod
     def get_public_types() -> List["BuildType"]:

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -215,8 +215,9 @@ def validate(parsed, unknown):
     # Check if any arguments are still unknown
     if unknown:
         runnable = f"{os.path.basename(sys.argv[0])} {parsed.command}"
+        msg = f"'{runnable}' supplied invalid arguments: {','.join(unknown)}"
         raise ArgValidationException(
-            f"'{runnable}' supplied invalid arguments: {','.join(unknown)}"
+            msg
         )
     parsed.build_cache = (
         None if parsed.build_cache is None else Path(parsed.build_cache)

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -216,9 +216,7 @@ def validate(parsed, unknown):
     if unknown:
         runnable = f"{os.path.basename(sys.argv[0])} {parsed.command}"
         msg = f"'{runnable}' supplied invalid arguments: {','.join(unknown)}"
-        raise ArgValidationException(
-            msg
-        )
+        raise ArgValidationException(msg)
     parsed.build_cache = (
         None if parsed.build_cache is None else Path(parsed.build_cache)
     )

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -106,8 +106,9 @@ def run_hash_to_file(
     """
     lines = build.find_hashed_file(parsed.hash)
     if not lines:
+        msg = f"Hash 0x{parsed.hash:x} not found. Do you need '--ut' for a unittest run?"
         raise InvalidBuildCacheException(
-            f"Hash 0x{parsed.hash:x} not found. Do you need '--ut' for a unittest run?"
+            msg
         )
     print("[INFO] File(s) associated with hash 0x{:x}".format(parsed.hash))
     for line in lines:

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -106,10 +106,10 @@ def run_hash_to_file(
     """
     lines = build.find_hashed_file(parsed.hash)
     if not lines:
-        msg = f"Hash 0x{parsed.hash:x} not found. Do you need '--ut' for a unittest run?"
-        raise InvalidBuildCacheException(
-            msg
+        msg = (
+            f"Hash 0x{parsed.hash:x} not found. Do you need '--ut' for a unittest run?"
         )
+        raise InvalidBuildCacheException(msg)
     print("[INFO] File(s) associated with hash 0x{:x}".format(parsed.hash))
     for line in lines:
         print("   ", line, end="")

--- a/src/fprime/util/versioning.py
+++ b/src/fprime/util/versioning.py
@@ -24,18 +24,21 @@ def get_version(package: str, requirements: Path):
             line.strip() for line in file_handle.readlines() if package in line
         ]
     if not matching_lines:
-        raise VersionException(f"Could not find {package} in requirements file")
+        msg = f"Could not find {package} in requirements file"
+        raise VersionException(msg)
     valid_lines = [line for line in matching_lines if "==" in line or "@" in line]
     if not valid_lines:
+        msg = f"{package} has inexact version, use '==' or '@' format. Found: {matching_lines}"
         raise VersionException(
-            f"{package} has inexact version, use '==' or '@' format. Found: {matching_lines}"
+            msg
         )
 
     # Collapse versions that match
     versions = list({line.split("==")[-1].split("@")[-1] for line in valid_lines})
     if len(versions) != 1:
+        msg = f"Conflicting versions specified for {package}: {versions}"
         raise VersionException(
-            f"Conflicting versions specified for {package}: {versions}"
+            msg
         )
     return versions[0]
 

--- a/src/fprime/util/versioning.py
+++ b/src/fprime/util/versioning.py
@@ -29,17 +29,13 @@ def get_version(package: str, requirements: Path):
     valid_lines = [line for line in matching_lines if "==" in line or "@" in line]
     if not valid_lines:
         msg = f"{package} has inexact version, use '==' or '@' format. Found: {matching_lines}"
-        raise VersionException(
-            msg
-        )
+        raise VersionException(msg)
 
     # Collapse versions that match
     versions = list({line.split("==")[-1].split("@")[-1] for line in valid_lines})
     if len(versions) != 1:
         msg = f"Conflicting versions specified for {package}: {versions}"
-        raise VersionException(
-            msg
-        )
+        raise VersionException(msg)
     return versions[0]
 
 

--- a/test/fprime/common/models/serialize/test_types.py
+++ b/test/fprime/common/models/serialize/test_types.py
@@ -471,10 +471,10 @@ def test_time_type():
     assert size == TIME_SIZE
     assert val.getMaxSize() == TIME_SIZE
 
-    for (t_base, t_context, secs, usecs) in in_no_err_list:
+    for t_base, t_context, secs, usecs in in_no_err_list:
         ser_deser_time_test(t_base, t_context, secs, usecs)
 
-    for (t_base, t_context, secs, usecs) in in_err_list:
+    for t_base, t_context, secs, usecs in in_err_list:
         with pytest.raises(TypeRangeException):
             ser_deser_time_test(t_base, t_context, secs, usecs)
 

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -34,9 +34,7 @@ def get_data_dir():
     if type(get_cmake_builder()) is fprime.fbuild.cmake.CMakeHandler:
         return os.path.join(os.path.dirname(__file__), "cmake-data")
     msg = f"Test data directory not setup for {type(get_cmake_builder())} builder class"
-    raise Exception(
-        msg
-    )
+    raise Exception(msg)
 
 
 def test_hash_finder():

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -33,8 +33,9 @@ def get_data_dir():
     """
     if type(get_cmake_builder()) is fprime.fbuild.cmake.CMakeHandler:
         return os.path.join(os.path.dirname(__file__), "cmake-data")
+    msg = f"Test data directory not setup for {type(get_cmake_builder())} builder class"
     raise Exception(
-        f"Test data directory not setup for {type(get_cmake_builder())} builder class"
+        msg
     )
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This feature implements the [flake8-err-msg](https://pypi.org/project/flake8-errmsg/) which allows the formatting of nice error messages.

## Rationale

The problem is that Python includes the line with the lift in the default traceback. This means that a user receives a message like this:

```py
sub = "Some value"
raise RuntimeError(f"{sub!r} is incorrect")
```

```sh
Traceback (most recent call last):
  File "tmp.py", line 2, in <module>
    raise RuntimeError(f"{sub!r} is incorrect")
RuntimeError: 'Some value' is incorrect
```

If it is longer or more complex, the duplication can be confusing for a user not used to reading tracebacks.

On the other hand, if you always assign to something like msg, you get :

```py
sub = "Some value"
msg = f"{sub!r} is incorrect"
raise RunetimeError(msg)
```

```sh
Traceback (most recent call last):
  File "tmp.py", line 3, in <module>
    raise RuntimeError(msg)
RuntimeError: 'Some value' is incorrect
```

There is now a more straightforward trace, less code and no double messages.

[Ref - Ruff linter](https://beta.ruff.rs/docs/rules/f-string-in-exception/)

## Testing/Review Recommendations

Inspection is enough

## Future Work

https://github.com/fprime-community/fprime-tools/pull/140
