### PR TITLE
Add consistency to imports based on `isort` settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import sphinx_rtd_theme  # pylint: disable=unused-import
 
-
 # importlib.metadata is implemented in Python 3.8
 # Previous versions require the backport, https://pypi.org/project/importlib-metadata/
 try:

--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -3,15 +3,15 @@
 Created on May 29, 2020
 @author: jishii
 """
+from fprime.util.string_util import format_string_template
+
+from . import serializable_type
 from .type_base import DictionaryType
 from .type_exceptions import (
     ArrayLengthException,
     NotInitializedException,
     TypeMismatchException,
 )
-
-from . import serializable_type
-from fprime.util.string_util import format_string_template
 
 
 class ArrayType(DictionaryType):

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -4,6 +4,9 @@ Created on Dec 18, 2014
 @author: tcanham
 
 """
+from fprime.util.string_util import format_string_template
+
+from . import array_type
 from .type_base import BaseType, DictionaryType
 from .type_exceptions import (
     IncorrectMembersException,
@@ -11,9 +14,6 @@ from .type_exceptions import (
     NotInitializedException,
     TypeMismatchException,
 )
-
-from . import array_type
-from fprime.util.string_util import format_string_template
 
 
 class SerializableType(DictionaryType):

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -21,9 +21,10 @@ import datetime
 import math
 from enum import Enum
 
+from fprime.common.models.serialize import type_base
+
 # Custom Python Modules
 from fprime.common.models.serialize.numerical_types import U8Type, U16Type, U32Type
-from fprime.common.models.serialize import type_base
 from fprime.common.models.serialize.type_exceptions import TypeRangeException
 
 TimeBase = Enum(

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/pre_gen_project.py
@@ -1,5 +1,6 @@
 from fprime.util.cookiecutter_wrapper import is_valid_name
 
+
 # Check to ensure Component Name is valid
 def verify_inputs(component_name, commands, events, telemetry, parameters):
     if is_valid_name(component_name) != "valid":

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -9,8 +9,8 @@ It does the following:
 
 @author thomas-bc
 """
-import sys
 import subprocess
+import sys
 
 DEFAULT_BRANCH = "devel"
 

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -7,21 +7,20 @@ import re
 from pathlib import Path
 from typing import Iterable, List, Union
 
+# Forces targets into existence
+import fprime.fbuild.target_definitions  # lgtm[py/unused-import]
+from fprime.common.error import FprimeException
+from fprime.fbuild.cmake import CMakeException, CMakeHandler
+from fprime.fbuild.settings import IniSettings
+from fprime.fbuild.target import Target, TargetScope
 from fprime.fbuild.types import (
+    AmbiguousToolchainException,
     BuildType,
     InvalidBuildCacheException,
     MissingBuildCachePath,
     NoSuchToolchainException,
-    AmbiguousToolchainException,
     UnableToDetectDeploymentException,
 )
-from fprime.fbuild.target import TargetScope, Target
-from fprime.common.error import FprimeException
-from fprime.fbuild.settings import IniSettings
-from fprime.fbuild.cmake import CMakeHandler, CMakeException
-
-# Forces targets into existence
-import fprime.fbuild.target_definitions  # lgtm[py/unused-import]
 
 
 class Build:

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -7,11 +7,12 @@ target operations.
 """
 import argparse
 from pathlib import Path
-from typing import Dict, List, Tuple, Callable
-from fprime.fbuild.types import BuildType
-from fprime.fbuild.target import Target
-from fprime.fbuild.builder import Build
+from typing import Callable, Dict, List, Tuple
+
 from fprime.common.utils import confirm
+from fprime.fbuild.builder import Build
+from fprime.fbuild.target import Target
+from fprime.fbuild.types import BuildType
 
 
 def get_target(parsed: argparse.Namespace) -> Target:

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
-from .target import ExecutableAction, Target, TargetScope, CompositeTarget
+from .target import CompositeTarget, ExecutableAction, Target, TargetScope
 
 
 def _get_project_path(builder: "Build", module: Union[str, Path]) -> Path:

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -6,12 +6,12 @@ settings from the settings.default file that is part of the F prime deployment d
 
 @author mstarch
 """
-import os
 import configparser
-from functools import partial
+import os
 from enum import Enum
-from typing import Dict, List, Union, Callable, Any
+from functools import partial
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Union
 
 
 class SettingType(Enum):

--- a/src/fprime/fbuild/target.py
+++ b/src/fprime/fbuild/target.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
+
 from .types import BuildType, NoSuchTargetException
 
 

--- a/src/fprime/fbuild/target_definitions.py
+++ b/src/fprime/fbuild/target_definitions.py
@@ -4,9 +4,9 @@ Defines all the targets for fprime-util. Each target is a singleton that is regi
 as such, each target need only be instantiated but need not be assigned to anything.
 
 """
-from .types import BuildType
-from .target import TargetScope, BuildSystemTarget
 from .gcovr import GcovrTarget
+from .target import BuildSystemTarget, TargetScope
+from .types import BuildType
 
 #### "build" targets for components, deployments, unittests for both normal and testing builds ####
 BuildSystemTarget(

--- a/src/fprime/fpp/cli.py
+++ b/src/fprime/fpp/cli.py
@@ -5,7 +5,8 @@ Processing and command line functions for FPP tools wrappers in fprime-util.
 @mstarch
 """
 import argparse
-from typing import Dict, List, Tuple, Callable
+from typing import Callable, Dict, List, Tuple
+
 from fprime.fpp.common import FppUtility
 
 

--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -6,8 +6,8 @@ Common implementations for FPP tool wrapping.
 """
 import itertools
 import subprocess
-from typing import List, Dict, Tuple
 from pathlib import Path
+from typing import Dict, List, Tuple
 
 from fprime.common.error import FprimeException
 from fprime.fbuild.builder import Build

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -15,10 +15,11 @@ are supported herein:
 """
 from pathlib import Path
 
-from fprime.fbuild.target import NoSuchTargetException
 from fprime.fbuild.builder import Build, BuildType
-from .versioning import get_version, VersionException
 from fprime.fbuild.cli import get_target
+from fprime.fbuild.target import NoSuchTargetException
+
+from .versioning import VersionException, get_version
 
 # Attempt to get pkg_resources from "setuptools"
 try:

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -5,22 +5,19 @@ Defines main entrypoint for fprime-util and sets up parsers for general CLI targ
 @author mstarch
 """
 import argparse
-import sys
-import re
 import os
-
+import re
+import sys
 from pathlib import Path
-from typing import Dict, Callable
+from typing import Callable, Dict
 
-from fprime.fbuild.target import Target
-from fprime.fbuild.cli import add_fbuild_parsers
 from fprime.fbuild.builder import GenerateException, UnableToDetectDeploymentException
-
+from fprime.fbuild.cli import add_fbuild_parsers
+from fprime.fbuild.target import Target
 from fprime.fpp.cli import add_fpp_parsers
-
-from fprime.util.help_text import HelpText
 from fprime.util.build_helper import load_build
-from fprime.util.commands import run_hash_to_file, run_info, run_new, run_code_format
+from fprime.util.commands import run_code_format, run_hash_to_file, run_info, run_new
+from fprime.util.help_text import HelpText
 
 
 def utility_entry(args):

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -5,15 +5,13 @@ Wrapper for clang-format utility.
 @author thomas-bc
 """
 
+import re
+import shutil
+import subprocess
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 from fprime.fbuild.target import ExecutableAction, TargetScope
-from pathlib import Path
-
-import subprocess
-import shutil
-import re
-
 
 # MARKER is needed to differentiate at postprocess between access specifiers
 # that were previously an uppercase MACRO, and those that were originally lowercase.

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -12,18 +12,16 @@ Current commands include:
 
 import argparse
 import sys
-
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List
 
 from fprime.fbuild.builder import Build, InvalidBuildCacheException
-
+from fprime.util.code_formatter import ClangFormatter
 from fprime.util.cookiecutter_wrapper import (
     new_component,
     new_deployment,
     new_project,
 )
-from fprime.util.code_formatter import ClangFormatter
 
 
 def run_info(

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -1,19 +1,19 @@
 """ Cookie cutter wrapper used to template out components
 """
-import os
 import glob
-import sys
-from pathlib import Path
-from contextlib import contextmanager
+import os
 import shutil
+import sys
+from contextlib import contextmanager
+from pathlib import Path
 
-from cookiecutter.main import cookiecutter
 from cookiecutter.exceptions import OutputDirExistsException
+from cookiecutter.main import cookiecutter
 
 from fprime.common.utils import confirm
 from fprime.fbuild.builder import Build
-from fprime.fbuild.target import Target
 from fprime.fbuild.cmake import CMakeExecutionException
+from fprime.fbuild.target import Target
 from fprime.util.code_formatter import ClangFormatter
 
 

--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -18,7 +18,6 @@ long paragraph description
 import os
 import sys
 
-
 # Attempt to get pkg_resources from "setuptools"
 try:
     import pkg_resources

--- a/src/fprime/util/string_util.py
+++ b/src/fprime/util/string_util.py
@@ -7,8 +7,8 @@ Utility functions to process strings to be used in FPrime GDS
 Note: This function has an identical copy in fprime-gds
 """
 
-import re
 import logging
+import re
 
 LOGGER = logging.getLogger("string_util_logger")
 

--- a/test/fprime/common/models/serialize/test_types.py
+++ b/test/fprime/common/models/serialize/test_types.py
@@ -8,7 +8,6 @@ import json
 from collections.abc import Iterable
 
 import pytest
-
 from fprime.common.models.serialize.array_type import ArrayType
 from fprime.common.models.serialize.bool_type import BoolType
 from fprime.common.models.serialize.enum_type import EnumType
@@ -28,7 +27,6 @@ from fprime.common.models.serialize.serializable_type import SerializableType
 from fprime.common.models.serialize.string_type import StringType
 from fprime.common.models.serialize.time_type import TimeBase, TimeType
 from fprime.common.models.serialize.type_base import BaseType, DictionaryType, ValueType
-
 from fprime.common.models.serialize.type_exceptions import (
     AbstractMethodException,
     ArrayLengthException,
@@ -41,7 +39,6 @@ from fprime.common.models.serialize.type_exceptions import (
     TypeMismatchException,
     TypeRangeException,
 )
-
 
 PYTHON_TESTABLE_TYPES = [
     True,

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -9,10 +9,9 @@ that they function as expected.
 import os
 import pathlib
 
-import pytest
-
-import fprime.fbuild.cmake
 import fprime.fbuild.builder
+import fprime.fbuild.cmake
+import pytest
 
 
 def get_cmake_builder():


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This PR consists of de-duplicating, grouping and sorting imports according to isort parameters.

## Rationale

This is to make the code base more consistent, as using a common convention for imports makes the code more readable and idiomatic.

[Ref - Ruff linter](https://beta.ruff.rs/docs/rules/unsorted-imports/)

## Testing/Review Recommendations

Visual inspection

## Future Work

Add Ruff linter into repo's CI (https://github.com/fprime-community/fprime-tools/pull/140).