### PR TITLE
Fix urllib3 version to prevent breakages on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ to interact with the data coming from the FSW.
         "Cheetah3>=3.2.6",
         "cookiecutter>=1.7.2",
         "gcovr>=6.0",
-        "urllib3==1.26.16",  # Cannot upgrade to 2.0.0 until SSL works on macOS
+        "urllib3<2.0.0",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ to interact with the data coming from the FSW.
         "Cheetah3>=3.2.6",
         "cookiecutter>=1.7.2",
         "gcovr>=6.0",
-        "urllib3==1.26.16" # Cannot upgrade to 2.0.0 until SSL works on macOS
+        "urllib3==1.26.16",  # Cannot upgrade to 2.0.0 until SSL works on macOS
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ to interact with the data coming from the FSW.
         "Cheetah3>=3.2.6",
         "cookiecutter>=1.7.2",
         "gcovr>=6.0",
+        "urllib3==1.26.16" # Cannot upgrade to 2.0.0 until SSL works on macOS
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

urllib3>=2.0.0 breaks on macOS over SSL versioning.  This fixes the package version until `urllib3` comes up with a solution.