### PR TITLE
Refactor `new` build system structure (nasa#1994)

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
@@ -1,5 +1,4 @@
 {
     "deployment_name": "MyDeployment",
-    "path_to_fprime": "./fprime",
     "__deployment_name_upper": "{{cookiecutter.deployment_name.upper()}}"
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/CMakeLists.txt
@@ -1,32 +1,22 @@
 #####
 # '{{cookiecutter.deployment_name}}' Deployment:
 #
-# This sets up the build for the '{{cookiecutter.deployment_name}}' Application, including custom
-# components. In addition, it imports FPrime.cmake, which includes the core F Prime components.
+# This registers the '{{cookiecutter.deployment_name}}' deployment to the build system. 
+# Custom components that have not been added at the project-level should be added to 
+# the list below.
 #
 #####
 
 ###
-# Basic Project Setup
-###
-cmake_minimum_required(VERSION 3.13)
-cmake_policy(SET CMP0048 NEW)
-project({{cookiecutter.deployment_name}} VERSION 1.0.0 LANGUAGES C CXX)
-
-###
-# F' Core Setup
-# This includes all of the F prime core components, and imports the make-system.
-###
-include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime.cmake")
-# NOTE: register custom targets between these two lines
-include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime-Code.cmake")
-
-###
-# Components and Topology
+# Topology and Components
 ###
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Top/")
 
+# Add custom components to this specific deployment here
+# add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/MyComponent/")
+
+
 set(SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/Main.cpp")
-set(MOD_DEPS ${PROJECT_NAME}/Top)
+set(MOD_DEPS ${FPRIME_CURRENT_MODULE}/Top)
 
 register_fprime_deployment()

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/settings.ini
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/settings.ini
@@ -5,3 +5,5 @@ framework_path: ../{{ cookiecutter.path_to_fprime.lstrip('./') }}
 
 default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
                         FPRIME_ENABLE_AUTOCODER_UTS=OFF
+
+#TODO: can't delete this otherwise fprime-gds does not run from here??

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/settings.ini
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/settings.ini
@@ -1,9 +1,0 @@
-; For more information: https://nasa.github.io/fprime/UsersGuide/user/settings.html
-[fprime]
-project_root: ../
-framework_path: ../{{ cookiecutter.path_to_fprime.lstrip('./') }}
-
-default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
-                        FPRIME_ENABLE_AUTOCODER_UTS=OFF
-
-#TODO: can't delete this otherwise fprime-gds does not run from here??

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
@@ -1,6 +1,7 @@
 {
+    "__default_branch": "master",
     "project_name": "MyProject",
-    "fprime_branch_or_tag": "devel",
+    "fprime_branch_or_tag": "{{ cookiecutter.__default_branch }}",
     "install_venv": ["yes", "no"],
     "venv_install_path": "{% if cookiecutter.install_venv == 'yes' %}./venv{% else %}None{% endif %}"
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "__default_branch": "master",
+    "__default_branch": "devel",
     "project_name": "MyProject",
     "fprime_branch_or_tag": "{{ cookiecutter.__default_branch }}",
     "install_venv": ["yes", "no"],

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "MyProject",
-    "fprime_branch_or_tag": "master",
+    "fprime_branch_or_tag": "devel",
     "install_venv": ["yes", "no"],
     "venv_install_path": "{% if cookiecutter.install_venv == 'yes' %}./venv{% else %}None{% endif %}"
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -12,7 +12,8 @@ It does the following:
 import subprocess
 import sys
 
-DEFAULT_BRANCH = "devel"
+# Fail-safe in case user input is invalid branch/tag
+DEFAULT_BRANCH = "{{ cookiecutter.__default_branch }}"
 
 # Add F' as a submodule
 subprocess.run(["git", "init"])

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -12,7 +12,7 @@ It does the following:
 import subprocess
 import sys
 
-DEFAULT_BRANCH = "master"
+DEFAULT_BRANCH = "devel"
 
 # Add F' as a submodule
 subprocess.run(["git", "init"])

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,6 +1,8 @@
 ####
-# 
+# This sets up the build system for the '{{cookiecutter.project_name}}' project, including
+# components and deployments from project.cmake. In addition, it imports the core F Prime components.
 ####
+
 cmake_minimum_required(VERSION 3.13)
 project({{cookiecutter.project_name}} C CXX)
 

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/Components/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/Components/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Include project-wide components here
+
+# add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/MyComponent")

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/project.cmake
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/project.cmake
@@ -1,2 +1,4 @@
-# This CMake file is intended to register project-wide objects so they can be
-# reused easily between deployments, but also by other projects.
+# This CMake file is intended to register project-wide objects.
+# This allows for reuse between deployments, or other projects.
+
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Components")

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/settings.ini
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/settings.ini
@@ -1,3 +1,6 @@
 [fprime]
 project_root: .
 framework_path: ./fprime
+
+default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
+                        FPRIME_ENABLE_AUTOCODER_UTS=OFF

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -80,7 +80,7 @@ def validate_tools_from_requirements(build: Build):
             print(message)
 
 
-def load_build(parsed):
+def load_build(parsed, skip_validation=False):
     """
     Loads Build object and returns it to the caller. Additionally, this will validate the
     installed tool versions (such as fpp and other F' utilities) against the requirements.txt
@@ -110,15 +110,11 @@ def load_build(parsed):
     if parsed.command == "generate":
         build.invent(parsed.platform, build_dir=parsed.build_cache)
     else:
-        does_not_need_cache_directory = parsed.command in [
-            "purge",
-            "info",
-            "format",
-        ]
+
         build.load(
             parsed.platform,
             parsed.build_cache,
-            skip_validation=does_not_need_cache_directory,
+            skip_validation=skip_validation,
         )
     validate_tools_from_requirements(build)
     return build

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -25,7 +25,11 @@ def utility_entry(args):
     parsed, cmake_args, make_args, parser, runners = parse_args(args)
 
     try:
-        build = None if skip_build_loading(parsed) else load_build(parsed)
+        build = (
+            None
+            if skip_build_loading(parsed)
+            else load_build(parsed, skip_build_cache_validation(parsed))
+        )
 
         # runners is a Dict[str, Callable] of {command_name: handler_functions} pairs
         return runners[parsed.command](
@@ -46,10 +50,24 @@ def utility_entry(args):
 
 def skip_build_loading(parsed):
     """Determines if the build load step should be skipped. Commands that do not require a build object
-    should manually be added here by the developer."""
-    if parsed.command == "new" and parsed.new_deployment:
-        return True
+    should manually be added here by the developer.
+    """
     if parsed.command == "new" and parsed.new_project:
+        return True
+    return False
+
+
+def skip_build_cache_validation(parsed):
+    """Determines if the build cache validation step should be skipped. Commands that do not require a
+    build **cache** should manually be added here by the developer.
+    """
+    if parsed.command in [
+        "purge",
+        "info",
+        "format",
+    ]:
+        return True
+    if parsed.command == "new" and parsed.new_deployment:
         return True
     return False
 

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -128,7 +128,7 @@ def run_new(
     if parsed.new_component:
         return new_component(build)
     if parsed.new_deployment:
-        return new_deployment(parsed)
+        return new_deployment(build, parsed)
     if parsed.new_project:
         return new_project(parsed)
     raise NotImplementedError(

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -225,7 +225,9 @@ def new_deployment(build: Build, parsed_args):
     )
     print("[INFO] Cookiecutter: using builtin template for new deployment")
     try:
-        gen_path = Path(cookiecutter(source, overwrite_if_exists=parsed_args.overwrite)).resolve()
+        gen_path = Path(
+            cookiecutter(source, overwrite_if_exists=parsed_args.overwrite)
+        ).resolve()
 
         proj_root = build.get_settings("project_root", None)
         # Attempt to register to CMakeLists.txt or project.cmake


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Architectures(s)_**| `fprime-util new` |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/pull/1994 https://github.com/nasa/fprime/issues/2002 |


---
## Change Description

Addresses https://github.com/nasa/fprime/issues/2002

https://github.com/nasa/fprime/pull/1994 introduced a new structure for projects where the CMake project() can be defined at the top level of the project tree only, and not within deployments. This modifies the `fprime-util new` commands to account for that.

I also took the liberty to add the `Components/` module to the project generation tree because it sounds to me like a good pattern to suggest to users - while it does not force anything onto them.

**Note:** I had to revert back the default fprime version `new --project` pulls since #1994 is only in devel for now.

## Testing/Review Recommendations

Checkout, install, and verify that `fprime-util new --project && fprime-util new --deployment` generates a buildable and runnable project.

## Future Work

- Switch default project F´ version back to master for next release.
- _Somewhat unrelated_, `fprime-gds` should automatically detect the deployment's `build-artifacts/` when ran within the deployment module. Currently, we need to pass in `-d ../build-artifacts/MyDeployment` or run at the top level of the project tree.