### PR TITLE
Feature: FPP Visualize

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -75,6 +75,7 @@ filepath
 firest
 floordiv
 FPGA
+fpl
 fpp
 fprime
 fromkeys
@@ -230,6 +231,7 @@ stylesheet
 subdir
 subparser
 Subproc
+subtopology
 sys
 tcanham
 Tcp

--- a/src/fprime/fpp/cli.py
+++ b/src/fprime/fpp/cli.py
@@ -34,6 +34,30 @@ def run_fpp_check(
         args=({}, ["-u", parsed.unconnected] if parsed.unconnected else []),
     )
 
+def run_fpp_to_xml(
+    build: "Build",
+    parsed: argparse.Namespace,
+    _: Dict[str, str],
+    __: Dict[str, str],
+    ___: List[str],
+):
+    """Run fpp check application
+
+    Handles the fpp-check endpoint by running the utility fpp-check.
+
+    Args:
+        build: build directory output
+        parsed: parsed input arguments
+        _: unused cmake_args
+        __: unused make_args
+        ___: unused pass-through arguments
+    """
+    FppUtility("fpp-to-xml").execute(
+        build,
+        parsed.path,
+        args=({}, ["--directory", parsed.directory] if parsed.directory else []),
+    )
+
 
 def add_fpp_parsers(
     subparsers, common: argparse.ArgumentParser
@@ -56,4 +80,10 @@ def add_fpp_parsers(
     check_parser.add_argument(
         "-u", "--unconnected", default=None, help="write unconnected ports to file"
     )
-    return {"fpp-check": run_fpp_check}, {"fpp-check": check_parser}
+    fpp_to_xml_parser = subparsers.add_parser(
+        "fpp-to-xml", help="Runs fpp-to-xml utility", parents=[common], add_help=False
+    )
+    fpp_to_xml_parser.add_argument(
+        "--directory", default=None, help="Output directory"
+    )
+    return {"fpp-check": run_fpp_check, "fpp-to-xml": run_fpp_to_xml}, {"fpp-check": check_parser, "fpp-to-xml": fpp_to_xml_parser}

--- a/src/fprime/fpp/cli.py
+++ b/src/fprime/fpp/cli.py
@@ -34,6 +34,7 @@ def run_fpp_check(
         args=({}, ["-u", parsed.unconnected] if parsed.unconnected else []),
     )
 
+
 def run_fpp_to_xml(
     build: "Build",
     parsed: argparse.Namespace,
@@ -83,7 +84,8 @@ def add_fpp_parsers(
     fpp_to_xml_parser = subparsers.add_parser(
         "fpp-to-xml", help="Runs fpp-to-xml utility", parents=[common], add_help=False
     )
-    fpp_to_xml_parser.add_argument(
-        "--directory", default=None, help="Output directory"
-    )
-    return {"fpp-check": run_fpp_check, "fpp-to-xml": run_fpp_to_xml}, {"fpp-check": check_parser, "fpp-to-xml": fpp_to_xml_parser}
+    fpp_to_xml_parser.add_argument("--directory", default=None, help="Output directory")
+    return {"fpp-check": run_fpp_check, "fpp-to-xml": run_fpp_to_xml}, {
+        "fpp-check": check_parser,
+        "fpp-to-xml": fpp_to_xml_parser,
+    }

--- a/src/fprime/fpp/cli.py
+++ b/src/fprime/fpp/cli.py
@@ -42,9 +42,7 @@ def run_fpp_to_xml(
     __: Dict[str, str],
     ___: List[str],
 ):
-    """Run fpp check application
-
-    Handles the fpp-check endpoint by running the utility fpp-check.
+    """Run the fpp-to-xml utility
 
     Args:
         build: build directory output

--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -45,7 +45,7 @@ class FppUtility(ExecutableAction):
         super().__init__(TargetScope.LOCAL)
         self.utility = name
 
-    def is_supported(self):
+    def is_supported(self, _ = None, __ = None):
         """Returns whether this utility is supported"""
         return bool(shutil.which(self.utility))
 

--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -7,6 +7,8 @@ Common implementations for FPP tool wrapping.
 import itertools
 import subprocess
 from pathlib import Path
+import shutil
+import sys
 from typing import Dict, List, Tuple
 
 from fprime.common.error import FprimeException
@@ -42,6 +44,10 @@ class FppUtility(ExecutableAction):
         """
         super().__init__(TargetScope.LOCAL)
         self.utility = name
+    
+    def is_supported(self):
+        """Returns whether this utility is supported"""
+        return bool(shutil.which(self.utility))
 
     @staticmethod
     def get_locations_file(builder: Build) -> Path:
@@ -98,6 +104,14 @@ class FppUtility(ExecutableAction):
             args: extra arguments to supply to the utility
         """
         # First refresh the cache but only if it detects it needs too
+
+        if not self.is_supported():
+            print(
+                f"[ERROR] Cannot find executable: {self.utility}.",
+                file=sys.stderr,
+            )
+            return 1
+
         builder.cmake.cmake_refresh_cache(builder.build_dir, False)
 
         # Read files and arguments

--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -44,7 +44,7 @@ class FppUtility(ExecutableAction):
         """
         super().__init__(TargetScope.LOCAL)
         self.utility = name
-    
+
     def is_supported(self):
         """Returns whether this utility is supported"""
         return bool(shutil.which(self.utility))

--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -45,7 +45,7 @@ class FppUtility(ExecutableAction):
         super().__init__(TargetScope.LOCAL)
         self.utility = name
 
-    def is_supported(self, _ = None, __ = None):
+    def is_supported(self, _=None, __=None):
         """Returns whether this utility is supported"""
         return bool(shutil.which(self.utility))
 

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -3,7 +3,6 @@
 @author thomas-bc
 """
 import argparse
-import os
 import subprocess
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
@@ -13,7 +12,7 @@ from fprime.fpp.common import FppUtility
 from fprime_visual.flask.app import construct_app
 
 
-def run_fpp_viz(
+def run_fprime_visualize(
     build: "Build",
     parsed: argparse.Namespace,
     _: Dict[str, str],
@@ -114,4 +113,4 @@ def add_fpp_viz_parsers(
     viz_parser.add_argument(
         "--gui-port", help="Set the GUI port for fprime-visual [default: 7000]", required=False, default=7000
     )
-    return {"visualize": run_fpp_viz}, {"visualize": viz_parser}
+    return {"visualize": run_fprime_visualize}, {"visualize": viz_parser}

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -14,7 +14,7 @@ from fprime.fpp.common import FppUtility
 FPL_INSTALL_DIR = "/Users/chammard/Work/fp/fprime-layout/bin"
 FPV_INSTALL_DIR = "/Users/chammard/Work/fp/fprime-visual"
 
-def run_fprime_viz(
+def run_fpp_viz(
     build: "Build",
     parsed: argparse.Namespace,
     _: Dict[str, str],
@@ -76,7 +76,7 @@ def run_fprime_viz(
 
 
 
-def add_fprime_viz_parsers(
+def add_fpp_viz_parsers(
     subparsers, common: argparse.ArgumentParser
 ) -> Tuple[Dict[str, Callable], Dict[str, argparse.ArgumentParser]]:
     """Sets up the fprime-viz command line parsers
@@ -97,4 +97,4 @@ def add_fprime_viz_parsers(
     viz_parser.add_argument(
         "-z", "--test", default=None, help="Test"
     )
-    return {"fpp-viz": run_fprime_viz}, {"fpp-viz": viz_parser}
+    return {"fpp-viz": run_fpp_viz}, {"fpp-viz": viz_parser}

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -46,9 +46,8 @@ def run_fprime_visualize(
             "fpl-layout is not installed. Please install with `pip install fprime-fpp>1.2.0`"
         )
 
-    # We could use the build directory, but it's quirky because not managed by CMake ??
-    viz_cache = Path(".fpp-viz-cache")
-    xml_cache = Path(".fpp-viz-cache/xml")
+    viz_cache = Path(parsed.cache_dir).resolve()
+    xml_cache = (viz_cache / "xml").resolve()
     xml_cache.mkdir(parents=True, exist_ok=True)
 
     # Run fpp-to-xml
@@ -57,8 +56,8 @@ def run_fprime_visualize(
         parsed.path,
         args=(
             {},
-            ["--directory", ".fpp-viz-cache/xml"],
-        ),  # ["--directory", parsed.directory] if parsed.directory else ["--directory", ".fpp-viz-cache"]),
+            ["--directory", str(xml_cache)],
+        ),
     )
     topology_match = list(xml_cache.glob("*TopologyAppAi.xml"))
     if len(topology_match) == 1:
@@ -108,7 +107,8 @@ def run_fprime_visualize(
                     ["fpl-layout"], stdin=txt_file, stdout=json_file, check=True
                 )
 
-    print("[INFO] Starting fprime-visual server...")
+    print( "[INFO] Starting fprime-visual server...")
+    print(f"[INFO] Serving files in {str(viz_cache.resolve())}")
     config = {"SOURCE_DIRS": [str(viz_cache.resolve())]}
     app = construct_app(config)
     try:
@@ -141,8 +141,14 @@ def add_fpp_viz_parsers(
     )
     viz_parser.add_argument(
         "--gui-port",
-        help="Set the GUI port for fprime-visual [default: 7000]",
+        help="Set the GUI port for fprime-visual [default: %(default)s]",
         required=False,
         default=7000,
+    )
+    viz_parser.add_argument(
+        "--cache-dir",
+        help="Set the directory to store layout files in [default: %(default)s]",
+        required=False,
+        default=".visualize-cache",
     )
     return {"visualize": run_fprime_visualize}, {"visualize": viz_parser}

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -1,15 +1,19 @@
-""" fprime.fpp.visualize: Command line targets for fprime-viz
+""" fprime.fpp.visualize: Command line targets for fprime-util visualize
 
 @author thomas-bc
 """
 import argparse
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
 
 from fprime.fpp.common import FppUtility
 
-from fprime_visual.flask.app import construct_app
+try:
+    from fprime_visual.flask.app import construct_app
+except ImportError:
+    construct_app = None
 
 
 def run_fprime_visualize(
@@ -32,6 +36,15 @@ def run_fprime_visualize(
         __: unused make_args
         ___: unused pass-through arguments
     """
+    if construct_app is None:
+        raise ModuleNotFoundError(
+            "fprime-visual is not installed. Please install with `pip install fprime-visual`"
+        )
+
+    if not (shutil.which("fpl-convert-xml") and shutil.which("fpl-layout")):
+        raise FileNotFoundError(
+            "fpl-layout is not installed. Please install with `pip install fprime-fpp>1.2.0`"
+        )
 
     # We could use the build directory, but it's quirky because not managed by CMake ??
     viz_cache = Path(".fpp-viz-cache")
@@ -72,7 +85,6 @@ def run_fprime_visualize(
             subprocess.run(["fpl-layout"], stdin=txt_file, stdout=json_file, check=True)
 
     print("Extracting subtopologies...")
-    # Extract subtopologies from Topology.xml
     extract_cache = viz_cache / "extracted"
     extract_cache.mkdir(parents=True, exist_ok=True)
     # Execute: fpl-extract-xml -d extracted/ Topology.xml

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -107,7 +107,7 @@ def run_fprime_visualize(
                     ["fpl-layout"], stdin=txt_file, stdout=json_file, check=True
                 )
 
-    print( "[INFO] Starting fprime-visual server...")
+    print("[INFO] Starting fprime-visual server...")
     print(f"[INFO] Serving files in {str(viz_cache.resolve())}")
     config = {"SOURCE_DIRS": [str(viz_cache.resolve())]}
     app = construct_app(config)

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -46,7 +46,7 @@ def run_fprime_visualize(
             "fpl-layout is not installed. Please install with `pip install fprime-fpp>1.2.0`"
         )
 
-    viz_cache = Path(parsed.cache_dir).resolve()
+    viz_cache = Path(parsed.working_dir).resolve()
     xml_cache = (viz_cache / "xml").resolve()
     xml_cache.mkdir(parents=True, exist_ok=True)
 
@@ -146,9 +146,9 @@ def add_fpp_viz_parsers(
         default=7000,
     )
     viz_parser.add_argument(
-        "--cache-dir",
+        "--working-dir",
         help="Set the directory to store layout files in [default: %(default)s]",
         required=False,
-        default=".visualize-cache",
+        default="/tmp/fprime-visualize",
     )
     return {"visualize": run_fprime_visualize}, {"visualize": viz_parser}

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -48,7 +48,12 @@ def run_fprime_visualize(
 
     viz_cache = Path(parsed.working_dir).resolve()
     xml_cache = (viz_cache / "xml").resolve()
-    xml_cache.mkdir(parents=True, exist_ok=True)
+    try:
+        xml_cache.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        raise PermissionError(
+            f"Unable to write to {viz_cache.resolve()}. Use --working-dir to set a different location."
+        )
 
     # Run fpp-to-xml
     FppUtility("fpp-to-xml").execute(

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -55,7 +55,7 @@ def run_fprime_visualize(
             tempfile.TemporaryDirectory(prefix="fprime-visual-").name
         ).resolve()
 
-    # Set subpaths for different types of generated files
+    # Set sub-paths for different types of generated files
     xml_cache = (viz_cache / "xml").resolve()
     extract_cache = (viz_cache / "extracted").resolve()
     try:

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -32,7 +32,7 @@ def run_fprime_visualize(
         __: unused make_args
         ___: unused pass-through arguments
     """
-    
+
     # We could use the build directory, but it's quirky because not managed by CMake ??
     viz_cache = Path(".fpp-viz-cache")
     xml_cache = Path(".fpp-viz-cache/xml")
@@ -42,14 +42,19 @@ def run_fprime_visualize(
     FppUtility("fpp-to-xml").execute(
         build,
         parsed.path,
-        args=({}, ["--directory", ".fpp-viz-cache/xml"]) #["--directory", parsed.directory] if parsed.directory else ["--directory", ".fpp-viz-cache"]),
+        args=(
+            {},
+            ["--directory", ".fpp-viz-cache/xml"],
+        ),  # ["--directory", parsed.directory] if parsed.directory else ["--directory", ".fpp-viz-cache"]),
     )
     topology_match = list(xml_cache.glob("*TopologyAppAi.xml"))
     if len(topology_match) == 1:
         topology_xml = topology_match[0]
     else:
-        raise Exception(f"Found {len(topology_match)} '*TopologyAppAi.xml' topology files - expected 1")
-    
+        raise Exception(
+            f"Found {len(topology_match)} '*TopologyAppAi.xml' topology files - expected 1"
+        )
+
     print(f"Generated topology XML file: {topology_xml.resolve()}")
 
     topology_txt = viz_cache / "Topology.txt"
@@ -57,11 +62,13 @@ def run_fprime_visualize(
 
     # Execute: fpl-convert-xml Topology.xml > Topology.txt
     with open(topology_txt.resolve(), "w") as txt_file:
-        subprocess.run(["fpl-convert-xml", topology_xml.resolve()], stdout=txt_file, check=True)
-    
+        subprocess.run(
+            ["fpl-convert-xml", topology_xml.resolve()], stdout=txt_file, check=True
+        )
+
     # Execute: fpl-layout < Topology.txt > Topology.json
     with open(topology_json.resolve(), "w") as json_file:
-        with open(topology_txt.resolve(), "r") as txt_file: 
+        with open(topology_txt.resolve(), "r") as txt_file:
             subprocess.run(["fpl-layout"], stdin=txt_file, stdout=json_file, check=True)
 
     print("Extracting subtopologies...")
@@ -69,18 +76,25 @@ def run_fprime_visualize(
     extract_cache = viz_cache / "extracted"
     extract_cache.mkdir(parents=True, exist_ok=True)
     # Execute: fpl-extract-xml -d extracted/ Topology.xml
-    subprocess.run(["fpl-extract-xml", "-d", extract_cache.resolve(), topology_xml.resolve()], check=True)
+    subprocess.run(
+        ["fpl-extract-xml", "-d", extract_cache.resolve(), topology_xml.resolve()],
+        check=True,
+    )
     subtopologies = list(extract_cache.glob("*.xml"))
     for subtopology in subtopologies:
         # Execute: fpl-convert-xml subtopology.xml > subtopology.txt
         subtopology_txt = extract_cache / f"{subtopology.stem}.txt"
         with open(subtopology_txt.resolve(), "w") as txt_file:
-            subprocess.run(["fpl-convert-xml", subtopology.resolve()], stdout=txt_file, check=True)
+            subprocess.run(
+                ["fpl-convert-xml", subtopology.resolve()], stdout=txt_file, check=True
+            )
         # Execute: fpl-layout < subtopology.txt > subtopology.json
         subtopology_json = viz_cache / f"{subtopology.stem}.json"
         with open(subtopology_json.resolve(), "w") as json_file:
-            with open(subtopology_txt.resolve(), "r") as txt_file: 
-                subprocess.run(["fpl-layout"], stdin=txt_file, stdout=json_file, check=True)
+            with open(subtopology_txt.resolve(), "r") as txt_file:
+                subprocess.run(
+                    ["fpl-layout"], stdin=txt_file, stdout=json_file, check=True
+                )
 
     print("[INFO] Starting fprime-visual server...")
     config = {"SOURCE_DIRS": [str(viz_cache.resolve())]}
@@ -108,9 +122,15 @@ def add_fpp_viz_parsers(
         Tuple of dictionary mapping command name to processor, and command to parser
     """
     viz_parser = subparsers.add_parser(
-        "visualize", help="Runs visualization pipeline", parents=[common], add_help=False
+        "visualize",
+        help="Runs visualization pipeline",
+        parents=[common],
+        add_help=False,
     )
     viz_parser.add_argument(
-        "--gui-port", help="Set the GUI port for fprime-visual [default: 7000]", required=False, default=7000
+        "--gui-port",
+        help="Set the GUI port for fprime-visual [default: 7000]",
+        required=False,
+        default=7000,
     )
     return {"visualize": run_fprime_visualize}, {"visualize": viz_parser}

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -18,6 +18,7 @@ from fprime.fpp.cli import add_fpp_parsers
 from fprime.util.build_helper import load_build
 from fprime.util.commands import run_code_format, run_hash_to_file, run_info, run_new
 from fprime.util.help_text import HelpText
+from fprime.visualize.cli import add_fprime_viz_parsers
 
 
 def utility_entry(args):
@@ -301,10 +302,13 @@ def parse_args(args):
         subparsers, common_parser, HelpText
     )
     fpp_runners, fpp_parsers = add_fpp_parsers(subparsers, common_parser)
+    viz_runners, viz_parsers = add_fprime_viz_parsers(subparsers, common_parser)
     parsers.update(fbuild_parsers)
     parsers.update(fpp_parsers)
+    parsers.update(viz_parsers)
     runners.update(fbuild_runners)
     runners.update(fpp_runners)
+    runners.update(viz_runners)
     runners.update(add_special_parsers(subparsers, common_parser, HelpText))
 
     # Parse and prepare to run

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -18,7 +18,7 @@ from fprime.fpp.cli import add_fpp_parsers
 from fprime.util.build_helper import load_build
 from fprime.util.commands import run_code_format, run_hash_to_file, run_info, run_new
 from fprime.util.help_text import HelpText
-from fprime.visualize.cli import add_fprime_viz_parsers
+from fprime.fpp.visualize import add_fpp_viz_parsers
 
 
 def utility_entry(args):
@@ -302,7 +302,7 @@ def parse_args(args):
         subparsers, common_parser, HelpText
     )
     fpp_runners, fpp_parsers = add_fpp_parsers(subparsers, common_parser)
-    viz_runners, viz_parsers = add_fprime_viz_parsers(subparsers, common_parser)
+    viz_runners, viz_parsers = add_fpp_viz_parsers(subparsers, common_parser)
     parsers.update(fbuild_parsers)
     parsers.update(fpp_parsers)
     parsers.update(viz_parsers)

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -55,7 +55,7 @@ class ClangFormatter(ExecutableAction):
         self.allowed_extensions = ALLOWED_EXTENSIONS.copy()
         self._files_to_format: List[Path] = []
 
-    def is_supported(self) -> bool:
+    def is_supported(self, _ = None, __ = None) -> bool:
         return bool(shutil.which(self.executable))
 
     def allow_extension(self, file_ext: str) -> None:

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -55,7 +55,7 @@ class ClangFormatter(ExecutableAction):
         self.allowed_extensions = ALLOWED_EXTENSIONS.copy()
         self._files_to_format: List[Path] = []
 
-    def is_supported(self, _ = None, __ = None) -> bool:
+    def is_supported(self, _=None, __=None) -> bool:
         return bool(shutil.which(self.executable))
 
     def allow_extension(self, file_ext: str) -> None:

--- a/src/fprime/visualize/cli.py
+++ b/src/fprime/visualize/cli.py
@@ -1,0 +1,100 @@
+""" fprime.visualize.cli: Command line targets for fprime-viz
+
+@thomas-bc
+"""
+import argparse
+from pathlib import Path
+# import os
+# import shutil
+import subprocess
+from typing import Callable, Dict, List, Tuple
+
+from fprime.fpp.common import FppUtility
+
+FPL_INSTALL_DIR = "/Users/chammard/Work/fp/fprime-layout/bin"
+FPV_INSTALL_DIR = "/Users/chammard/Work/fp/fprime-visual"
+
+def run_fprime_viz(
+    build: "Build",
+    parsed: argparse.Namespace,
+    _: Dict[str, str],
+    __: Dict[str, str],
+    ___: List[str],
+):
+    """Run pipeline of utilities to generate visualization. This includes:
+    - fpp-to-xml
+    - fpl-convert-xml
+    - fpl-layout
+    - start nodemon process to serve visualization
+
+    Args:
+        build: build directory output
+        parsed: parsed input arguments
+        _: unused cmake_args
+        __: unused make_args
+        ___: unused pass-through arguments
+    """
+    viz_cache = Path(".fpp-viz-cache")
+    xml_cache = Path(".fpp-viz-cache/xml")
+    xml_cache.mkdir(parents=True, exist_ok=True)
+    
+    # Run fpp-to-xml
+    FppUtility("fpp-to-xml").execute(
+        build,
+        parsed.path,
+        args=({}, ["--directory", ".fpp-viz-cache/xml"]) #["--directory", parsed.directory] if parsed.directory else ["--directory", ".fpp-viz-cache"]),
+    )
+    topology_match = list(xml_cache.glob("*TopologyAppAi.xml"))
+    if len(topology_match) == 1:
+        topology_xml = topology_match[0]
+    else:
+        raise Exception(f"Found {len(topology_match)} '*TopologyAppAi.xml' topology files - expected 1")
+    
+    print(f"Found topology XML file: {topology_xml.resolve()}")
+
+    topology_txt = viz_cache / "Topology.txt"
+    topology_json = viz_cache / "Topology.json"
+
+    # Execute: fpl-convert-xml Topology.xml > Topology.txt
+    with open(topology_txt.resolve(), "w") as txt_file:
+        subprocess.run([f"{FPL_INSTALL_DIR}/fpl-convert-xml", topology_xml.resolve()], stdout=txt_file, check=True)
+    
+    # Execute: fpl-layout < Topology.txt > Topology.json
+    with open(topology_json.resolve(), "w") as json_file:
+        with open(topology_txt.resolve(), "r") as txt_file: 
+            subprocess.run([f"{FPL_INSTALL_DIR}/fpl-layout"], stdin=txt_file, stdout=json_file, check=True)
+
+    # Run nodemon - this will eventually be replaced with Flask app so whatevs' is fine for now
+    fpv_env = viz_cache / ".fpv-env"
+    with open(fpv_env.resolve(), "w") as env_file:
+        env_file.write(f"DATA_FOLDER={viz_cache.resolve()}\n")
+    print("[INFO] Starting nodemon server...")
+    subprocess.run(["nodemon", f"{FPV_INSTALL_DIR}/server/index.js", fpv_env.resolve()], check=True)
+    return 0
+
+
+
+
+
+def add_fprime_viz_parsers(
+    subparsers, common: argparse.ArgumentParser
+) -> Tuple[Dict[str, Callable], Dict[str, argparse.ArgumentParser]]:
+    """Sets up the fprime-viz command line parsers
+
+    Creates command line parsers for fprime-viz commands and associates these commands to processing functions for those fpp
+    commands.
+
+    Args:
+        subparsers: subparsers to add to
+        common: common parser for all fprime-util commands
+
+    Returns:
+        Tuple of dictionary mapping command name to processor, and command to parser
+    """
+    viz_parser = subparsers.add_parser(
+        "fpp-viz", help="Runs visualization pipeline", parents=[common], add_help=False
+    )
+    viz_parser.add_argument(
+        "-z", "--test", default=None, help="Test"
+    )
+    return {"fpp-viz": run_fprime_viz}, {"fpp-viz": viz_parser}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2059 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

**Depends on**:
- https://github.com/fprime-community/fprime-visual/pull/1
- https://github.com/nasa/fprime/issues/2084

Introducing: `fprime-util visualize`
Within a Topology directory, performs the following

-  fpp-to-xml
-  fpl-convert-xml
-  fpl-layout
-  start fprime-visual Flask app to serve visualization

Effectively, this allows with a single command to spin up a visualization of the topology and all its subtopology graphs.

```bash
cd Ref/Top
fprime-util visualize
```

## Rationale

Major QoL improvement to visualization capabilities. This is currently doable, but requires a lot of manual installation of tools etc...

## Todo
- The 2 things listed in _Depends on_
- Probably add some tests

## Note

Opening as draft in case there's change requests. Do not merge for now, there are a couple of dependencies for this that need to be released before this can go through.