### PR TITLE
Fix invalid arg handling on generate

### DIFF
--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -220,6 +220,7 @@ def validate(parsed, unknown):
         d_args = {
             match.group(1): match.group(2)
             for match in [CMAKE_REG.match(arg) for arg in unknown]
+            if match is not None
         }
         cmake_args.update(d_args)
         unknown = [arg for arg in unknown if not CMAKE_REG.match(arg)]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes #127 
regex.match() returns `None` when no match is found, when what we want is not to append to the list. Excluding match is None from the comprehension fixes the issue.