### PR TITLE
Update default component namespace

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "component_name": "MyComponent",
     "component_short_description": "Example Component for F Prime FSW framework.",
-    "component_namespace": "{{cookiecutter.component_name}}",
+    "component_namespace": "Components",
     "component_kind": ["active", "passive", "queued"],
     "enable_commands": ["yes","no"],
     "enable_telemetry": ["yes","no"],


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Updates the default prompt for the namespace of a `new --component` to be `Components` instead of the component's name

## Rationale

This is the convention we use in most of our examples/tutorials.