### PR TITLE
Update cookiecutter prompts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ to interact with the data coming from the FSW.
         "pexpect>=4.8.0",
         "pytest>=6.2.4",
         "Cheetah3>=3.2.6",
-        "cookiecutter>=1.7.2",
+        "cookiecutter>=2.2.3",
         "gcovr>=6.0",
         "urllib3<2.0.0",
     ],

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/cookiecutter.json
@@ -11,20 +11,10 @@
         "component_name": "Component name",
         "component_short_description": "Component short description",
         "component_namespace": "Component namespace",
-        "component_kind": {
-          "__prompt__": "Select component kind"
-        },
-        "enable_commands": {
-            "__prompt__": "Enable Commands?"
-        },
-        "enable_telemetry": {
-            "__prompt__": "Enable Telemetry?"
-        },
-        "enable_events": {
-            "__prompt__": "Enable Events?"
-        },
-        "enable_parameters": {
-            "__prompt__": "Enable Parameters?"
-        }
+        "component_kind": "Select component kind",
+        "enable_commands": "Enable Commands?",
+        "enable_telemetry": "Enable Telemetry?",
+        "enable_events": "Enable Events?",
+        "enable_parameters": "Enable Parameters?"
       }
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/cookiecutter.json
@@ -1,10 +1,30 @@
 {
     "component_name": "MyComponent",
-    "component_short_description": "Example Component for F Prime FSW framework.",
+    "component_short_description": "Component for F Prime FSW framework.",
     "component_namespace": "Components",
     "component_kind": ["active", "passive", "queued"],
     "enable_commands": ["yes","no"],
     "enable_telemetry": ["yes","no"],
     "enable_events": ["yes","no"],
-    "enable_parameters": ["yes","no"]
+    "enable_parameters": ["yes","no"],
+    "__prompts__": {
+        "component_name": "Component name",
+        "component_short_description": "Component short description",
+        "component_namespace": "Component namespace",
+        "component_kind": {
+          "__prompt__": "Select component kind"
+        },
+        "enable_commands": {
+            "__prompt__": "Enable Commands?"
+        },
+        "enable_telemetry": {
+            "__prompt__": "Enable Telemetry?"
+        },
+        "enable_events": {
+            "__prompt__": "Enable Events?"
+        },
+        "enable_parameters": {
+            "__prompt__": "Enable Parameters?"
+        }
+      }
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "deployment_name": "MyDeployment",
-    "__deployment_name_upper": "{{cookiecutter.deployment_name.upper()}}"
+    "__deployment_name_upper": "{{cookiecutter.deployment_name.upper()}}",
+    "__prompts__": {
+        "deployment_name": "Deployment name"
+    }
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
@@ -6,7 +6,7 @@
     "venv_install_path": "{% if cookiecutter.install_venv == 'yes' %}./venv{% else %}None{% endif %}",
     "__prompts__": {
         "project_name": "Project name",
-        "fprime_branch_or_tag": "F' version (select branch or tag)",
+        "fprime_branch_or_tag": "F´ version (select branch or tag)",
         "install_venv": "Install virtual environment?",
         "venv_install_path": "Virtual environment install path"
     }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
@@ -3,5 +3,11 @@
     "project_name": "MyProject",
     "fprime_branch_or_tag": "{{ cookiecutter.__default_branch }}",
     "install_venv": ["yes", "no"],
-    "venv_install_path": "{% if cookiecutter.install_venv == 'yes' %}./venv{% else %}None{% endif %}"
+    "venv_install_path": "{% if cookiecutter.install_venv == 'yes' %}./venv{% else %}None{% endif %}",
+    "__prompts__": {
+        "project_name": "Project name",
+        "fprime_branch_or_tag": "F' version (select branch or tag)",
+        "install_venv": "Install virtual environment?",
+        "venv_install_path": "Virtual environment install path"
+    }
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes https://github.com/nasa/fprime/issues/2130

## Rationale

More human readable prompts. The feature was just released for cookiecutter - see issue above.

Example output:

```
$ fprime-util new --component
Component name [MyComponent]:
Component short description [Component for F Prime FSW framework.]:
Component namespace [Components]:
Select component kind:
1 - active
2 - passive
3 - queued
Choose from 1, 2, 3 [1]:
Enable Commands?:
1 - yes
2 - no
Choose from 1, 2 [1]:
Enable Telemetry?:
1 - yes
2 - no
Choose from 1, 2 [1]:
Enable Events?:
1 - yes
2 - no
Choose from 1, 2 [1]:
Enable Parameters?:
1 - yes
2 - no
```

## Future work
Update tutorials - I'm on it, opening PRs there in a sec