### PR TITLE
fix cookiecutter new proj template

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -10,7 +10,7 @@ project({{cookiecutter.project_name}} C CXX)
 # F' Core Setup
 # This includes all of the F prime core components, and imports the make-system.
 ###
-include("${CMAKE_CURRENT_LIST_DIR}/fprime/cmake/FPrime.cmake")
+include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime.cmake")
 # NOTE: register custom targets between these two lines
 include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime-Code.cmake")
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| fprime-tools |
|**_Affected Component_**| cookiecutter_templates |
|**_Affected Architectures(s)_**|  N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Cookiecutter's "new project" CMakeLists.txt template had "CMAKE_CURRENT_LIST_DIR" for FPrime.cmake file as shown below:

```cmake
include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime.cmake")
```

This works fine if fprime folder is inside the project folder, but won't work if the fprime repo is outside of the project folder.

With the new fix it does not matter where the fprime folder is located as the path will be found from FPRIME_FRAMEWORK_PATH.

```cmake
include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime.cmake")
```

## Rationale

There is an inconsistency in the generated CMakeLists.txt for the new projects by the cookiecutter.
both `FPrime.cmake` and `FPrime-Code.cmake` are in the cmake folder in the fprime repo, but one is being search in `CMAKE_CURRENT_LIST_DIR/fprime` and the other is being searched in  `${FPRIME_FRAMEWORK_PATH}/cmake`

## Testing/Review Recommendations

Created a new project with the cookiecutter CLI and got the following CMakeLists.txt
Also was able to generate and build the project with the new path.

```cmake
####
# This sets up the build system for the 'MyProject' project, including
# components and deployments from project.cmake. In addition, it imports the core F Prime components.
####

cmake_minimum_required(VERSION 3.13)
project(MyProject C CXX)

###
# F' Core Setup
# This includes all of the F prime core components, and imports the make-system.
###
include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime.cmake")
# NOTE: register custom targets between these two lines
include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime-Code.cmake")

# This includes project-wide objects
include("${CMAKE_CURRENT_LIST_DIR}/project.cmake")

```

## Future Work

The cookiecutter currently clones the fprime repository inside the project base folder. It would be more convenient to update the cookiecutter to prompt the user for the fprime folder's location. It can then search for the folder, and if found, there would be no need to clone it again. However, if the fprime folder is not found, the cookiecutter should proceed to clone the repository into the given location. Additionally, to accommodate users who prefer to install fprime in the project folder, the cookiecutter can have the default option of placing it in the project root folder.
