### PR TITLE
Validate for new build structure

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -442,7 +442,7 @@ class Build:
         exist.
 
         Notes:
-            Historically, the root of the CMake project was an F' deployment. In F' > v3.2.0, this is more often an 
+            Historically, the root of the CMake project was an F' deployment. In F' > v3.2.0, this is more often an
             F' project root.
 
         Returns;

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -194,10 +194,10 @@ def add_special_targets(
     generate_parser = subparsers.add_parser(
         "generate",
         help=help_text.short(
-            "generate", "Generate a build cache for specified deployment"
+            "generate", "Generate a build cache for specified project"
         ),
         description=help_text.long(
-            "generate", "Generate a build cache for specified deployment"
+            "generate", "Generate a build cache for specified project"
         ),
         parents=[common],
         add_help=False,
@@ -218,9 +218,9 @@ def add_special_targets(
     )
     purge_parser = subparsers.add_parser(
         "purge",
-        help=help_text.short("purge", "Remove build caches for specified deployment"),
+        help=help_text.short("purge", "Remove build caches for specified project"),
         description=help_text.long(
-            "purge", "Remove build caches for specified deployment"
+            "purge", "Remove build caches for specified project"
         ),
         add_help=False,
         parents=[common],

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -31,7 +31,7 @@ def _get_project_path(builder: "Build", module: Union[str, Path]) -> Path:
 
 def _using_root(builder: "Build", context: Path, scope: TargetScope):
     """Are we using repository root for things"""
-    return builder.is_deployment(context) or scope == TargetScope.GLOBAL
+    return builder.is_project_root(context) or scope == TargetScope.GLOBAL
 
 
 class GcovClean(ExecutableAction):

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -179,7 +179,10 @@ class IniSettings:
         else:
             print(f"[WARNING] {settings_file} does not exist")
 
-        settings = {"settings_file": settings_file, "_cmake_project_root": settings_file.parent}
+        settings = {
+            "settings_file": settings_file,
+            "_cmake_project_root": settings_file.parent,
+        }
 
         # Read fprime and platform settings from the "fprime" section
         for key, settings_type, default in (

--- a/src/fprime/fbuild/settings.py
+++ b/src/fprime/fbuild/settings.py
@@ -1,8 +1,8 @@
 """
 fprime.fbuild.settings:
 
-An implementation used to pull settings into the fprime build.  This version uses INI files in order to load the
-settings from the settings.default file that is part of the F prime deployment directory.
+An implementation used to pull settings into the fprime build. This version uses INI files in order
+to load the settings from the settings.default file that is part of the F prime project directory.
 
 @author mstarch
 """
@@ -26,11 +26,11 @@ def find_fprime(settings: dict) -> Path:
     """
     Finds F prime by recursing parent to parent until a matching directory is found.
     """
-    needle = Path("cmake/FPrime.cmake")
-    path = settings["_deployment"]
+    needle = Path("fprime/cmake/FPrime.cmake")
+    path = settings["_cmake_project_root"]
     while path != path.parent:
         if (path / needle).is_file():
-            return path
+            return path / "fprime"
         path = path.parent
     raise FprimeLocationUnknownException(
         "Please set 'framework_path' in [fprime] section in 'settings.ini"
@@ -72,7 +72,7 @@ class IniSettings:
         (
             "install_destination",
             SettingType.PATH,
-            partial(join, "_deployment", "build-artifacts"),
+            partial(join, "_cmake_project_root", "build-artifacts"),
         ),
         (
             "environment_file",
@@ -179,7 +179,7 @@ class IniSettings:
         else:
             print(f"[WARNING] {settings_file} does not exist")
 
-        settings = {"settings_file": settings_file, "_deployment": settings_file.parent}
+        settings = {"settings_file": settings_file, "_cmake_project_root": settings_file.parent}
 
         # Read fprime and platform settings from the "fprime" section
         for key, settings_type, default in (
@@ -211,7 +211,7 @@ class IniSettings:
         settings["environment"] = IniSettings.load_environment(
             settings["environment_file"]
         )
-        del settings["_deployment"]
+        del settings["_cmake_project_root"]
         return settings
 
     @staticmethod

--- a/src/fprime/fbuild/types.py
+++ b/src/fprime/fbuild/types.py
@@ -12,7 +12,7 @@ class InvalidBuildCacheException(FprimeException):
         self.cache = build_cache
 
 
-class UnableToDetectDeploymentException(FprimeException):
+class UnableToDetectProjectException(FprimeException):
     """An exception indicating a build cache"""
 
 

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -92,13 +92,13 @@ def load_build(parsed, skip_validation=False):
     except NoSuchTargetException:
         build_type = BuildType.BUILD_TESTING if parsed.ut else BuildType.BUILD_NORMAL
 
-    deployment = (
-        Path(parsed.deploy)
-        if parsed.deploy is not None
-        else Build.find_nearest_deployment(Path.cwd())  # Deployments look in CWD
+    cmake_root = (
+        Path(parsed.root)
+        if parsed.root is not None
+        else Build.find_nearest_parent_project(Path.cwd())
     )
 
-    build = Build(build_type, deployment, verbose=parsed.verbose)
+    build = Build(build_type, cmake_root, verbose=parsed.verbose)
 
     # All commands need to load the build cache to setup the basic information for the build with the exception of
     # generate, which is run before the creation of the build cache and thus must invent the cache instead. This

--- a/src/fprime/util/build_helper.py
+++ b/src/fprime/util/build_helper.py
@@ -110,7 +110,6 @@ def load_build(parsed, skip_validation=False):
     if parsed.command == "generate":
         build.invent(parsed.platform, build_dir=parsed.build_cache)
     else:
-
         build.load(
             parsed.platform,
             parsed.build_cache,

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Callable, Dict
 
-from fprime.fbuild.builder import GenerateException, UnableToDetectDeploymentException
+from fprime.fbuild.builder import GenerateException, UnableToDetectProjectException
 from fprime.fbuild.cli import add_fbuild_parsers
 from fprime.fbuild.target import Target
 from fprime.fpp.cli import add_fpp_parsers
@@ -41,8 +41,8 @@ def utility_entry(args):
             f"[ERROR] {genex}. Partial build cache remains. Run purge to clean-up.",
             file=sys.stderr,
         )
-    except UnableToDetectDeploymentException:
-        print(f"[ERROR] Could not detect deployment directory for: {parsed.path}")
+    except UnableToDetectProjectException:
+        print(f"[ERROR] Could not detect project directory for: {parsed.path}")
     except Exception as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
     return 1
@@ -256,11 +256,10 @@ def parse_args(args):
         help="F prime build platform (e.g. Linux, Darwin). Default specified in settings.ini",
     )
     common_parser.add_argument(
-        "-d",
-        "--deploy",
-        dest="deploy",
+        "-r",
+        "--root",
         default=None,
-        help="F prime deployment directory to use. May contain multiple build directories.",
+        help="Root of CMake project to use. May contain multiple build directories.",
     )
     common_parser.add_argument(
         "-p",

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -171,9 +171,7 @@ def new_component(build: Build):
             )
             print("[INFO] Cookiecutter source: using builtin")
 
-        final_component_dir = Path(
-            cookiecutter(source)
-        ).resolve()
+        final_component_dir = Path(cookiecutter(source)).resolve()
 
         if proj_root is None:
             print(
@@ -183,7 +181,9 @@ def new_component(build: Build):
 
         # Attempt to register to CMakeLists.txt
         proj_root = Path(proj_root)
-        cmake_file = find_nearest_cmake_file(final_component_dir, build.cmake_root, proj_root)
+        cmake_file = find_nearest_cmake_file(
+            final_component_dir, build.cmake_root, proj_root
+        )
         if cmake_file is None or not add_to_cmake(
             cmake_file,
             final_component_dir.relative_to(cmake_file.parent),

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -171,7 +171,14 @@ def new_component(build: Build):
             )
             print("[INFO] Cookiecutter source: using builtin")
 
-        final_component_dir = Path(cookiecutter(source)).resolve()
+        # Use current working directory name as default namespace, unless at project root
+        extra_context = {}
+        if not proj_root.samefile(Path.cwd()):
+            extra_context["component_namespace"] = Path.cwd().name
+
+        final_component_dir = Path(
+            cookiecutter(source, extra_context=extra_context)
+        ).resolve()
 
         if proj_root is None:
             print(

--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -37,7 +37,7 @@ build system targets defined for that context. i.e. a developer can change direc
 commands restricted to that component.
 
 Almost all {EXECUTABLE} commands require a valid build cache to run. Thus users should start by running '{EXECUTABLE}
-generate' in their desired deployment before running command. Once a build cache has been generated other commands can
+generate' in their desired project before running command. Once a build cache has been generated other commands can
 be run. The '--ut' flag sets up a testing build cache and enables unit test commands to be run. An explanation of how
 {EXECUTABLE} determines the build cache is included below. More information on creating build caches can be found with:
 '{EXECUTABLE} generate --help'.
@@ -65,10 +65,10 @@ to determine two build properties: build cache (created by 'fprime-util generate
 execute. The build cache is chosen by recurring upward from the current working directory looking for the first build
 cache matching the specified platform. If '--ut' is specified, only UT caches will be selected. The platform is read
 from the optional positional argument 'platform'. If not specified on the command line, the 'default_toolchain' setting
-in the deployment's settings.ini file is read. In not specified there, the default toolchain "native" is used.
+in the project's settings.ini file is read. If not specified there, the default toolchain "native" is used.
 
-If a different deployment is desired, the recursive search behavior can be altered with the '-d/--deployment'. When
-'-d/--deployment' is specified, a matching build cache will be selected from within the supplied deployment directory.
+If a different CMake root is desired, the recursive search behavior can be altered with the '-r/--root'. When
+'-r/--root' is specified, a matching build cache will be selected from within the supplied root directory.
 '--build-cache' may be supplied to force '{EXECUTABLE}' to use the supplied build cache regardless of other conditions.
 
 Once the build cache has been selected, the build target is chosen. {EXECUTABLE} will run the supplied command for
@@ -92,7 +92,7 @@ Contextual Examples:
 
   -- Build Command Dispatcher UTs for Ref Deployment --
   cd Svc/CmdDispatcher
-  {EXECUTABLE} build --ut -d ../../Ref/
+  {EXECUTABLE} build --ut -r ../../Ref/
 
   -- Build Command Dispatcher UTs for Ref Deployment (Alternate) --
   cd Ref
@@ -189,9 +189,9 @@ Examples:
     "generate": f"""{EXECUTABLE} generate ({VERSION}): Generate build caches for the specified deployment
 
 '{EXECUTABLE} generate' is used to setup a build cache to support other commands run by {EXECUTABLE}. Without additional
-arguments a build cache will be created for the deployment in the specified directory ('-p/--path', or current working
-directory). It will use the default settings specified in the deployment's settings.ini file for the target platform,
-fprime libraries, etc. Specifying '-d/--deployment' generates the deployment at the supplied directory overriding the
+arguments a build cache will be created for the project in the specified directory ('-p/--path', or current working
+directory). It will use the default settings specified in the project's settings.ini file for the target platform,
+fprime libraries, etc. Specifying '-r/--root' generates the project at the supplied directory overriding the
 directory specified with '-p/--path' and the current working directory. '--ut' should be specified to generate testing
 build caches for running unit tests.
 
@@ -236,10 +236,10 @@ CMake Flag Examples:
   {EXECUTABLE} generate --build-cache `pwd`/build-ref-with-baremetal -DFPRIME_USE_BAREMETAL_SCHEDULER=ON
 
 """,
-    "purge": f"""{EXECUTABLE} purge ({VERSION}): Removes build caches for specified deployment
+    "purge": f"""{EXECUTABLE} purge ({VERSION}): Removes build caches for specified project
     
-'{EXECUTABLE} purge' removes build caches for the specified deployment. It also removes the build_artifacts directory
-in that deployment as well. Caches are searched in pairs: normal build cache, paired unit testing build cache. The
+'{EXECUTABLE} purge' removes build caches for the specified project. It also removes the build_artifacts directory
+in that project as well. Caches are searched in pairs: normal build cache, paired unit testing build cache. The
 user will be asked to confirm when a build cache is being removed unless the '--force' flag is specified. The platform
 will use the settings specified in 'settings.ini' or as specified with the optional positional argument. The
 '--build-cache' flag can be used to remove an exact build cache without looking at other build caches.
@@ -250,7 +250,7 @@ supplied. In this case, the build cache will be removed with reckless abandon.
     "info": f"""Print contextual target and build cache information before exiting
 
 '{EXECUTABLE} info' is used to print contextual information to the user before exiting. It will print the available]
-commands within the current context (working directory, '-p/--path', '-d/--deployment', etc.) and then exit. Users may
+commands within the current context (working directory, '-p/--path', '-r/--root', etc.) and then exit. Users may
 use the info command as a way to test and understand how {EXECUTABLE} is mapping to the context and targets used. info
 may also be used to locate the artifact output folders within the build cache in order to see generated files, compiler
 outputs, etc.

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -172,7 +172,7 @@ def test_get_include_info():
                 assert value == truth
 
 
-def test_find_nearest_deployment():
+def test_find_nearest_parent_project():
     """
     This will test the ability for the system to detect valid deployment directories
     """
@@ -188,8 +188,8 @@ def test_find_nearest_deployment():
         path = test_dir / path
         if truth is not None:
             truth = test_dir / truth
-            value = fprime.fbuild.builder.Build.find_nearest_deployment(path)
+            value = fprime.fbuild.builder.Build.find_nearest_parent_project(path)
             assert value == truth
         else:
-            with pytest.raises(fprime.fbuild.builder.UnableToDetectDeploymentException):
-                fprime.fbuild.builder.Build.find_nearest_deployment(path)
+            with pytest.raises(fprime.fbuild.builder.UnableToDetectProjectException):
+                fprime.fbuild.builder.Build.find_nearest_parent_project(path)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2094 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Making sure we're still relevant for the new build structure introduced by https://github.com/nasa/fprime/pull/1994
Correcting "assumptions" in the code that _deployment==cmake project_, which mostly came down to variable names and vocabulary.
I had to scrub a minor thing in `new --component` that would use the deployment's name as default prompt for component namespace, if the command is ran from a deployment. I thought about switching to using CWD's name, since that's usually what I've seen being used.

## Testing/Review Recommendations

I tested as much as I could with projects on the old and new build structure, as well as with core fprime. 
