### PR TITLE
Add hidden files to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ to interact with the data coming from the FSW.
             "cookiecutter_templates/*/*",
             "cookiecutter_templates/*/*/*",
             "cookiecutter_templates/*/*/*/*",
+            "cookiecutter_templates/**/.*",
         ]
     },
     ####


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes https://github.com/nasa/fprime/issues/2179

`.gitignore` was not being added to the package because the `package_data` glob pattern was not matching hidden files. Adding it explicitly.

I unfortunately missed that during testing, because I usually use `pip install -e ...` which uses source files directly.