### PR TITLE
Add ComDriver select for new deployments

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,6 +1,7 @@
 argc
 atoi
 bak
+baudrate
 Callee
 cargs
 CDH
@@ -168,6 +169,7 @@ Pkts
 Popen
 postprocessed
 printf
+PRIu
 proj
 ptf
 py
@@ -252,6 +254,7 @@ typehints
 typename
 tz
 tzinfo
+uart
 Udp
 uint
 Uncomment

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
@@ -1,7 +1,9 @@
 {
     "deployment_name": "MyDeployment",
+    "com_driver_type": ["TcpClient", "TcpServer", "UART"],
     "__deployment_name_upper": "{{cookiecutter.deployment_name.upper()}}",
     "__prompts__": {
-        "deployment_name": "Deployment name"
+        "deployment_name": "Deployment name",
+        "com_driver_type": "Select communication driver type"
     }
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
@@ -60,14 +60,18 @@ int main(int argc, char* argv[]) {
 {%- endif %}
 
     // Loop while reading the getopt supplied options
+{%- if cookiecutter.com_driver_type == "UART" %}
+    while ((option = getopt(argc, argv, "hb:d:")) != -1) {  
+{%- else %}
     while ((option = getopt(argc, argv, "hp:a:")) != -1) {
+{%- endif %}
         switch (option) {
 {%- if cookiecutter.com_driver_type == "UART" %}
             // Handle the -b baud rate argument
             case 'b':
                 baud_rate = static_cast<U32>(atoi(optarg));
                 break;
-            // Handle the -p port number argument
+            // Handle the -d device argument
             case 'd':
                 uart_device = optarg;
                 break;

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
@@ -20,7 +20,11 @@
  * @param app: name of application
  */
 void print_usage(const char* app) {
+{%- if cookiecutter.com_driver_type == "UART" %}
+    (void)printf("Usage: ./%s [options]\n-b\tBaud rate\n-d\tUART Device\n", app);
+{%- else %}
     (void)printf("Usage: ./%s [options]\n-a\thostname/IP address\n-p\tport_number\n", app);
+{%- endif %}
 }
 
 /**
@@ -46,13 +50,28 @@ static void signalHandler(int signum) {
  * @return: 0 on success, something else on failure
  */
 int main(int argc, char* argv[]) {
-    U32 port_number = 0;
     I32 option = 0;
+{%- if cookiecutter.com_driver_type == "UART" %}
+    char* uart_device = nullptr;
+    U32 baud_rate = 0;
+{%- else %}
     char* hostname = nullptr;
+    U32 port_number = 0;
+{%- endif %}
 
     // Loop while reading the getopt supplied options
     while ((option = getopt(argc, argv, "hp:a:")) != -1) {
         switch (option) {
+{%- if cookiecutter.com_driver_type == "UART" %}
+            // Handle the -b baud rate argument
+            case 'b':
+                baud_rate = static_cast<U32>(atoi(optarg));
+                break;
+            // Handle the -p port number argument
+            case 'd':
+                uart_device = optarg;
+                break;
+{%- else %}
             // Handle the -a argument for address/hostname
             case 'a':
                 hostname = optarg;
@@ -61,6 +80,7 @@ int main(int argc, char* argv[]) {
             case 'p':
                 port_number = static_cast<U32>(atoi(optarg));
                 break;
+{%- endif %}
             // Cascade intended: help output
             case 'h':
             // Cascade intended: help output
@@ -73,8 +93,13 @@ int main(int argc, char* argv[]) {
     }
     // Object for communicating state to the reference topology
     {{cookiecutter.deployment_name}}::TopologyState inputs;
+{%- if cookiecutter.com_driver_type == "UART" %}
+    inputs.baudRate = baud_rate;
+    inputs.uartDevice = uart_device;
+{%- else %}
     inputs.hostname = hostname;
     inputs.port = port_number;
+{%- endif %}
 
     // Setup program shutdown via Ctrl-C
     signal(SIGINT, signalHandler);

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
@@ -52,11 +52,11 @@ static void signalHandler(int signum) {
 int main(int argc, char* argv[]) {
     I32 option = 0;
 {%- if cookiecutter.com_driver_type == "UART" %}
-    char* uart_device = nullptr;
+    CHAR* uart_device = nullptr;
     U32 baud_rate = 0;
 {%- else %}
-    char* hostname = nullptr;
-    U32 port_number = 0;
+    CHAR* hostname = nullptr;
+    U16 port_number = 0;
 {%- endif %}
 
     // Loop while reading the getopt supplied options
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
                 break;
             // Handle the -p port number argument
             case 'p':
-                port_number = static_cast<U32>(atoi(optarg));
+                port_number = static_cast<U16>(atoi(optarg));
                 break;
 {%- endif %}
             // Cascade intended: help output

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/CMakeLists.txt
@@ -16,7 +16,13 @@ set(MOD_DEPS
   Svc/LinuxTime
   # Communication Implementations
   Drv/Udp
+{%- if cookiecutter.com_driver_type == "TcpClient" %}
   Drv/TcpClient
+{%- elif cookiecutter.com_driver_type == "TcpServer" %}
+  Drv/TcpServer
+{%- elif cookiecutter.com_driver_type == "UART" %}
+  Drv/LinuxUartDriver
+{%- endif %}
 )
 
 register_fprime_module()

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/instances.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/instances.fpp
@@ -98,11 +98,19 @@ module {{cookiecutter.deployment_name}} {
   # Passive component instances
   # ----------------------------------------------------------------------
 
-  @ Communications driver. May be swapped with other comm drivers like UART
+  @ Communications driver. May be swapped with other com drivers like UART or TCP
+{%- if cookiecutter.com_driver_type == "UART" %}
+  instance comDriver: Drv.LinuxUartDriver base id 0x4000
+{%- else %}
   @ Note: Here we have TCP reliable uplink and UDP (low latency) downlink
   instance comDriver: Drv.ByteStreamDriverModel base id 0x4000 \
+{%- if cookiecutter.com_driver_type == "TcpServer" %}
+    type "Drv::TcpServer" \ # type specified to select implementor of ByteStreamDriverModel
+    at "../../Drv/TcpServer/TcpServer.hpp" # location of above implementor must also be specified
+{%- elif cookiecutter.com_driver_type == "TcpClient" %}
     type "Drv::TcpClient" \ # type specified to select implementor of ByteStreamDriverModel
     at "../../Drv/TcpClient/TcpClient.hpp" # location of above implementor must also be specified
+{%- endif -%}{% endif %}
 
   instance framer: Svc.Framer base id 0x4100
 

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Packets.xml
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Packets.xml
@@ -44,6 +44,10 @@
     <packet name="Comms" id="4" level="1">
         <channel name="comQueue.comQueueDepth"/>
         <channel name="comQueue.buffQueueDepth"/>
+{%- if cookiecutter.com_driver_type == "UART" %}
+        <channel name="comDriver.BytesSent"/>
+        <channel name="comDriver.BytesRecv"/>
+{%- endif %}
     </packet>
 
     <packet name="SystemRes1" id="5" level="2">

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Packets.xml
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Packets.xml
@@ -44,10 +44,6 @@
     <packet name="Comms" id="4" level="1">
         <channel name="comQueue.comQueueDepth"/>
         <channel name="comQueue.buffQueueDepth"/>
-{%- if cookiecutter.com_driver_type == "UART" %}
-        <channel name="comDriver.BytesSent"/>
-        <channel name="comDriver.BytesRecv"/>
-{%- endif %}
     </packet>
 
     <packet name="SystemRes1" id="5" level="2">
@@ -86,5 +82,9 @@
 
     <ignore>
         <channel name="cmdDisp.CommandErrors"/>
+{%- if cookiecutter.com_driver_type == "UART" %}
+        <channel name="comDriver.BytesSent"/>
+        <channel name="comDriver.BytesRecv"/>
+{%- endif %}
     </ignore>
 </packets>

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -167,7 +167,7 @@ void setupTopology(const TopologyState& state) {
         Os::TaskString name("ReceiveTask");
         // Uplink is configured for receive so a socket task is started
         if (comDriver.open(state.uartDevice, static_cast<Drv::LinuxUartDriver::UartBaudRate>(state.baudRate), 
-                           Drv::LinuxUartDriver::NO_FLOW, Drv::LinuxUartDriver::PARITY_NONE, 1024)) {
+                           Drv::LinuxUartDriver::NO_FLOW, Drv::LinuxUartDriver::PARITY_NONE, Svc::DeframerCfg::RING_BUFFER_SIZE)) {
             comDriver.startReadThread(COMM_PRIORITY, Default::STACK_SIZE);
         } else {
             printf("Failed to open UART device %s at baud rate %" PRIu32 "\n", state.uartDevice, state.baudRate);

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
@@ -34,7 +34,7 @@ namespace {{cookiecutter.deployment_name}} {
  * The state argument carries command line inputs used to setup the topology. For an explanation of the required type
  * {{cookiecutter.deployment_name}}::TopologyState see: {{cookiecutter.deployment_name}}TopologyDefs.hpp.
  *
- * \param state: object shuttling CLI arguments (hostname, port) needed to construct the topology
+ * \param state: object shuttling CLI arguments (e.g. hostname/port, or UART baudrate) needed to construct the topology
  */
 void setupTopology(const TopologyState& state);
 

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
@@ -19,13 +19,17 @@ namespace {{cookiecutter.deployment_name}} {
  * \brief required type definition to carry state
  *
  * The topology autocoder requires an object that carries state with the name `{{cookiecutter.deployment_name}}::TopologyState`. Only the type
- * definition is required by the autocoder and the contents of this object are otherwise opaque to the autocoder. The
- * contents are entirely up to the definition of the project. This reference application specifies hostname and port
- * fields, which are derived by command line inputs.
+ * definition is required by the autocoder and the contents of this object are otherwise opaque to the autocoder. The contents are entirely up
+ * to the definition of the project. Here, they are derived from command line inputs.
  */
 struct TopologyState {
+{%- if (cookiecutter.com_driver_type == "UART") %}
+    const char* uartDevice;
+    PlatformUIntType baudRate;
+{%- else %}
     const char* hostname;
-    U32 port;
+    PlatformUIntType port;
+{%- endif %}
 };
 
 /**

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
@@ -24,11 +24,11 @@ namespace {{cookiecutter.deployment_name}} {
  */
 struct TopologyState {
 {%- if (cookiecutter.com_driver_type == "UART") %}
-    const char* uartDevice;
-    PlatformUIntType baudRate;
+    const CHAR* uartDevice;
+    U32 baudRate;
 {%- else %}
-    const char* hostname;
-    PlatformUIntType port;
+    const CHAR* hostname;
+    U16 port;
 {%- endif %}
 };
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2191 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Add cookiecutter option to select which type of ComDriver to use for new deployments. Select between UART, TcpClient and TcpServer.

