### PR TITLE
Fix arguments order for generate stage

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -329,7 +329,9 @@ class Build:
             and self.build_type == BuildType.BUILD_TESTING
         ):
             cmake_args["BUILD_TESTING"] = "ON"
-            cmake_args["CMAKE_BUILD_TYPE"] = user_cmake_args.get("CMAKE_BUILD_TYPE", "Debug")
+            cmake_args["CMAKE_BUILD_TYPE"] = user_cmake_args.get(
+                "CMAKE_BUILD_TYPE", "Debug"
+            )
         elif self.build_type == BuildType.BUILD_TESTING:
             cmake_args["CMAKE_BUILD_TYPE"] = "Testing"
         return cmake_args

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -396,11 +396,20 @@ class Build:
             cmake_args.update(user_cmake_args)  # User-supplied values from command line
             cmake_args.update(self.get_cmake_args())  # FPRIME_* values (settings.ini)
 
-            if self.build_type == BuildType.BUILD_TESTING:
+            # When the new v3 autocoder directory exists, this means we can use the new UT api and preserve the build type
+            v3_autocoder_directory = Path(
+                cmake_args.get("FPRIME_FRAMEWORK_PATH") / "cmake" / "autocoder"
+            )
+            if (
+                v3_autocoder_directory.exists()
+                and self.build_type == BuildType.BUILD_TESTING
+            ):
                 cmake_args["BUILD_TESTING"] = "ON"
                 cmake_args["CMAKE_BUILD_TYPE"] = user_cmake_args.get(
                     "CMAKE_BUILD_TYPE", "Debug"
                 )
+            elif self.build_type == BuildType.BUILD_TESTING:
+                cmake_args["CMAKE_BUILD_TYPE"] = "Testing"
 
             self.cmake.generate_build(
                 self.cmake_root,

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -408,7 +408,7 @@ class Build:
             self.cmake.generate_build(
                 self.cmake_root,
                 self.build_dir,
-                {**default_cmake_args, **cmake_args, **self.get_cmake_args()},
+                {**default_cmake_args, **self.get_cmake_args(), **cmake_args},
                 environment=self.settings.get("environment", None),
             )
         except CMakeException as cexc:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| fprime-util generate  |

---
## Change Description

Cmake arguments come from three different places: 
1. default
2. settings.ini
3. user-defined arguments when running fprime-util generate

Before this change, the order was the default, user-defined and settings.ini. Now I changed the order as reported above.

## Rationale

I was trying to set the -DCMAKE_BUILD_TYPE=Release  during the generation of the unit tests but I was not able to send anything else than Debug. This was happening because when the arguments were read from  `settings.ini`, the build type was put by default to Debug. This overrides the build type set from the command line. 

With my change, the user-defined variable when running `fprime-util generate ...` overrides any other variable.
