### PR TITLE
Update CMake -D flags handling

### DIFF
--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -212,7 +212,7 @@ def add_special_targets(
     # The following option is specified only to show up in --help.
     # It is not handled by argparse, but in fprime.util.cli:validate()
     generate_parser.add_argument(
-        "-D<VAR>=<VALUE>",
+        "-D<VAR>[:<TYPE>]=<VALUE>",
         action="store_true",
         help="Pass -D flags through to CMake. Can be used multiple times.",
     )

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -213,6 +213,7 @@ def add_special_targets(
     # It is not handled by argparse, but in fprime.util.cli:validate()
     generate_parser.add_argument(
         "-D<VAR>=<VALUE>",
+        action="store_true",
         help="Pass -D flags through to CMake. Can be used multiple times.",
     )
     purge_parser = subparsers.add_parser(

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -210,10 +210,9 @@ def add_special_targets(
         action="store_true",
     )
     # The following option is specified only to show up in --help.
-    # It is not handled by , in fprime.util.cli:validate()
+    # It is not handled by argparse, but in fprime.util.cli:validate()
     generate_parser.add_argument(
         "-D<VAR>=<VALUE>",
-        action="store_true",
         help="Pass -D flags through to CMake. Can be used multiple times.",
     )
     purge_parser = subparsers.add_parser(

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -209,12 +209,12 @@ def add_special_targets(
         help="Disable the compiler sanitizers. Sanitizers are only enabled by default when --ut is provided.",
         action="store_true",
     )
+    # The following option is specified only to show up in --help.
+    # It is not handled by , in fprime.util.cli:validate()
     generate_parser.add_argument(
-        "-Dxyz",
-        action="append",
-        help="Pass -D flags through to CMakes",
-        nargs=1,
-        default=[],
+        "-D<VAR>=<VALUE>",
+        action="store_true",
+        help="Pass -D flags through to CMake. Can be used multiple times.",
     )
     purge_parser = subparsers.add_parser(
         "purge",

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -210,8 +210,8 @@ def validate(parsed, unknown):
     :param unknown: unknown arguments
     :return: cmake arguments to pass to CMake
     """
-    # regex pattern to detect -D<CMAKE_ARGUMENT>=<VALUE> arguments for CMake
-    CMAKE_REG = re.compile(r"-D([a-zA-Z0-9_]+)=(.*)")
+    # regex pattern to detect -D<CMAKE_ARGUMENT>[:<TYPE>]=<VALUE> arguments for CMake
+    CMAKE_REG = re.compile(r"-D([a-zA-Z0-9_]+(?::[A-Z]+)?)=(.*)")
     cmake_args = {}
     make_args = {}
     # Check platforms for existing toolchain, unless the default is specified.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| Fixes https://github.com/fprime-community/fprime-tools/issues/164 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes https://github.com/fprime-community/fprime-tools/issues/164

Clarifies the help text and adds in capability of recognizing cases where -D flag is of form `-DNAME:TYPE=VALUE`