### PR TITLE
Remove startup/shutdown call for TcpServer

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -157,9 +157,6 @@ void setupTopology(const TopologyState& state) {
         Os::TaskString name("ReceiveTask");
         // Uplink is configured for receive so a socket task is started
         comDriver.configure(state.hostname, state.port);
-{%-     if (cookiecutter.com_driver_type == "TcpServer") %}
-        comDriver.startup();
-{%-     endif %}
         comDriver.startSocketTask(name, true, COMM_PRIORITY, Default::STACK_SIZE);
     }
 {%- elif cookiecutter.com_driver_type == "UART" %}
@@ -212,9 +209,6 @@ void teardownTopology(const TopologyState& state) {
     comDriver.quitReadThread();
     (void)comDriver.join(nullptr);
 {%- else %}
-    {%- if (cookiecutter.com_driver_type == "TcpServer") %}
-    comDriver.shutdown();
-    {%- endif %}
     comDriver.stopSocketTask();
     (void)comDriver.joinSocketTask(nullptr);
 {%- endif %}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---

# TO BE MERGED AFTER https://github.com/nasa/fprime/pull/2261

## Change Description

Adjust TcpServer setup to adhere to https://github.com/nasa/fprime/pull/2261

## Rationale

Calls are not needed anymore.


