### PR TITLE
Install venv unless explicitly requested

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/cookiecutter.json
@@ -1,8 +1,7 @@
 {
     "project_name": "MyProject",
-    "install_venv": ["yes", "no"],
+    "__install_venv": "yes",
     "__prompts__": {
-        "project_name": "Project name",
-        "install_venv": "Install F´ development tools in current virtual environment?"
+        "project_name": "Project name"
     }
 }

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -49,7 +49,8 @@ if res.returncode != 0:
     sys.exit(1)  # sys.exit(1) indicates failure to cookiecutter
 
 # Install venv if requested
-if "{{cookiecutter.install_venv}}" == "yes":
+
+if "{{cookiecutter.__install_venv}}" == "yes":
     if sys.prefix != sys.base_prefix:
         subprocess.run(
             [

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -125,6 +125,12 @@ def add_special_parsers(
         action="store_true",
         help="Generated files will overwrite existing ones",
     )
+    new_parser.add_argument(
+        "--prevent-tools-installation",
+        default=False,
+        action="store_true",
+        help="Prevent the installation of the tool suite in the current virtual enviornment",
+    )
     new_exclusive = new_parser.add_argument_group(
         "'new' targets"
     ).add_mutually_exclusive_group()

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -129,7 +129,7 @@ def add_special_parsers(
         "--prevent-tools-installation",
         default=False,
         action="store_true",
-        help="Prevent the installation of the tool suite in the current virtual enviornment",
+        help="Prevent the installation of the tool suite in the current virtual environment",
     )
     new_exclusive = new_parser.add_argument_group(
         "'new' targets"
@@ -139,21 +139,21 @@ def add_special_parsers(
         default=False,
         action="store_true",
         dest="new_component",
-        help="Tells the new command to generate a component",
+        help="Generate a new component",
     )
     new_exclusive.add_argument(
         "--deployment",
         default=False,
         action="store_true",
         dest="new_deployment",
-        help="Tells the new command to generate a deployment",
+        help="Generate a new deployment",
     )
     new_exclusive.add_argument(
         "--project",
         default=False,
         action="store_true",
         dest="new_project",
-        help="Tells the new command to generate a project",
+        help="Generate a new project",
     )
 
     # Code formatting with clang-format

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -294,6 +294,7 @@ def new_project(parsed_args):
             source,
             overwrite_if_exists=parsed_args.overwrite,
             output_dir=parsed_args.path,
+            extra_context={"__install_venv": "no" if parsed_args.prevent_tools_installation else "yes"},
         )
     except OutputDirExistsException as out_directory_error:
         print(

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -294,7 +294,11 @@ def new_project(parsed_args):
             source,
             overwrite_if_exists=parsed_args.overwrite,
             output_dir=parsed_args.path,
-            extra_context={"__install_venv": "no" if parsed_args.prevent_tools_installation else "yes"},
+            extra_context={
+                "__install_venv": "no"
+                if parsed_args.prevent_tools_installation
+                else "yes"
+            },
         )
     except OutputDirExistsException as out_directory_error:
         print(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Makes the `install_venv` option a CLI flag instead of cookiecutter option. This is because not doing so may request in breakages, so we want to do it unless explicitly requested.