### PR TITLE
Fixing parallel builds

### DIFF
--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -232,7 +232,7 @@ def validate(parsed, unknown):
         cmake_args.update(d_args)
         unknown = [arg for arg in unknown if not CMAKE_REG.match(arg)]
     # Build type only for generate, jobs only for non-generate
-    elif parsed.command in Target.get_all_targets():
+    elif parsed.command in [target.mnemonic for target in Target.get_all_targets()]:
         parsed.settings = None  # Force to load from cache if possible
         make_args["--jobs"] = 1 if parsed.jobs <= 0 else parsed.jobs
     # Check if any arguments are still unknown


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes the parallel build `-jN` flag passing.  This has been broken since at least `v3.0.0`.  

## Rationale

Builds should be fast

## Testing/Review Recommendations

- [x] Tested `fprime-util build -j16`
- [x] Tested `fprime-util check -j16`

Much faster.

## Future Work

None
