### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,10 +7,10 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Check formatting
         run: |
           pip install click==8.0.4 black==21.6b0

--- a/.github/workflows/fprime-tools-ci.yml
+++ b/.github/workflows/fprime-tools-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         fprime-version: ["NASA-v1.5.3", "v2.0.0", "v3.0.0", "devel"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -72,15 +72,15 @@ to interact with the data coming from the FSW.
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    # Requires Python 3.7+
-    python_requires=">=3.7",
+    # Requires Python 3.8+
+    python_requires=">=3.8",
     install_requires=[
         "lxml>=4.6.3",
         "Markdown>=3.3.4",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Sunsetting Python 3.7 support

## Rationale

Python 3.7 came to end of life: https://endoflife.date/python
Support has been dropped on https://github.com/nasa/fprime
