### PR TITLE
Restricting visualization to current project if possible

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -29,6 +29,7 @@ lestarch
 LGTM
 lgtm
 Linux
+localhost
 Prm
 prm
 Serializables
@@ -36,3 +37,4 @@ serializables
 timezone
 Tlm
 tlm
+webbrowser

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -130,7 +130,7 @@ def run_fprime_visualize(
     config = {"SOURCE_DIRS": [str(viz_cache.resolve())]}
     app = construct_app(config)
     try:
-        webbrowser.open(f"http://localhost:{parsed.gui_port}")       
+        webbrowser.open(f"http://localhost:{parsed.gui_port}")
         app.run(port=parsed.gui_port)
     except KeyboardInterrupt:
         print("[INFO] CTRL-C received. Exiting.")

--- a/src/fprime/fpp/visualize.py
+++ b/src/fprime/fpp/visualize.py
@@ -6,6 +6,7 @@ import argparse
 import shutil
 import subprocess
 import tempfile
+import webbrowser
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
 
@@ -75,8 +76,11 @@ def run_fprime_visualize(
             ["--directory", str(xml_cache)],
         ),
     )
+    project_xml = xml_cache / f"{Path(build.cmake_root).name}TopologyAppAi.xml"
     topology_match = list(xml_cache.glob("*TopologyAppAi.xml"))
-    if len(topology_match) == 1:
+    if project_xml.exists():
+        topology_xml = project_xml
+    elif len(topology_match) == 1:
         topology_xml = topology_match[0]
     else:
         raise Exception(
@@ -126,6 +130,7 @@ def run_fprime_visualize(
     config = {"SOURCE_DIRS": [str(viz_cache.resolve())]}
     app = construct_app(config)
     try:
+        webbrowser.open(f"http://localhost:{parsed.gui_port}")       
         app.run(port=parsed.gui_port)
     except KeyboardInterrupt:
         print("[INFO] CTRL-C received. Exiting.")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**| fprime-util visualize |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| nasa/fprime/#2354  |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| y  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| na/ |

---
## Change Description

Uses a projects inferred name to sub-select a topology to visualize when running with sub-topolgies!

## Rationale

Subtopologies make multiple `AppAi.xml` files but the user just wants to visualize the composite topology not the sub topologies.  Visualizing just the subtopology can be done in the subtopology's module.

