### PR TITLE
Always print output when refreshing cache

### DIFF
--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -439,7 +439,7 @@ class CMakeHandler:
                 run_args,
                 write_override=True,
                 environment=environment,
-                print_output=self.verbose,
+                print_output=True,
             )
         else:
             if self.verbose:
@@ -450,7 +450,7 @@ class CMakeHandler:
                 None,
                 top_target=True,
                 full_cache_rebuild=True,
-                print_output=self.verbose,
+                print_output=True,
             )
 
     def _run_cmake(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1992 |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/1992

When `cmake_refresh_cache()` is triggered, always print the cmake regeneration output.

## Rationale

- This is consistent with the behavior that `fprime-util build` et al. have when target **exists** but requires a refresh (e.g. `.fpp` file was modified). Output of regeneration is printed out.
- Imo it helps new users (who may not be familiar with CMake) in understanding the build process. Target doesn't exist -> needs a refresh. Target is out of date -> needs a refresh. Refresh is the same thing happening under the hood in both cases (also `fprime-util generate`), and the familiar-looking output confirms that.
- Clears out any confusion with regards to https://github.com/nasa/fprime/issues/1992

## Comment
This has the side effect of also printing the `Built target noop` to the screen... which I don't really like.
I've been looking in other ways to do this, but was unsuccessful. A fix could be to go in the [CMakeHandler._communicate](https://github.com/thomas-bc/fprime-tools/blob/devel/src/fprime/fbuild/cmake.py#L566-L568) and explicitly skip lines that equal `Built target noop\n`, but that sounds rather ugly... 
Do you have any suggestion?
