### PR TITLE
Add project submodule initialization

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -94,6 +94,7 @@ getcwd
 getopt
 gh
 github
+googletest
 gtest
 gui
 hasattr

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip urllib3 setuptools_scm
       - name: clone fprime and gps-tutorial
         run: |
-          git clone -b ${{ matrix.fprime-version }} https://github.com/nasa/fprime.git
+          git clone --recurse-submodules -b ${{ matrix.fprime-version }} https://github.com/nasa/fprime.git
           git clone --recurse-submodules https://github.com/fprime-community/gps-tutorial.git
           pip install -r fprime/requirements.txt || true # Attempt to install fprime package when available
       - name: Generate correct fprime version in gps-tutorial

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -37,19 +37,26 @@ subprocess.run(
     cwd="./fprime",
     capture_output=True,
 )
+
 # Checkout requested branch/tag
 res = subprocess.run(
     ["git", "checkout", latest_tag_name],
     cwd="./fprime",
     capture_output=True,
 )
-
 if res.returncode != 0:
     print(f"[ERROR] Unable to checkout tag: {latest_tag_name}. Exit...")
     sys.exit(1)  # sys.exit(1) indicates failure to cookiecutter
 
-# Install venv if requested
+# Checkout submodules (e.g. googletest)
+res = subprocess.run(
+    ["git", "submodule", "update", "--init", "--recursive"],
+    capture_output=True,
+)
+if res.returncode != 0:
+    print("[WARNING] Unable to initialize submodules. Functionality may be limited.")
 
+# Install venv if requested
 if "{{cookiecutter.__install_venv}}" == "yes":
     if sys.prefix != sys.base_prefix:
         subprocess.run(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Add call to `git submodule update --init --recursive` to the `new --project` command.

## Rationale

googletest is now a submodule of fprime (see https://github.com/nasa/fprime/pull/2371)