### PR TITLE
Run FppUtility in `cwd=context`

### DIFF
--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -150,4 +150,6 @@ class FppUtility(ExecutableAction):
         app_args = [self.utility] + user_args + input_args
         if builder.cmake.verbose:
             print(f"[FPP] '{' '.join(app_args)}'")
-        return subprocess.run(app_args, capture_output=False).returncode
+        # NOTE: running in cwd=context because FPP behaves differently based on CWD (as of fpp v2.0.1)
+        # We may want to revisit in the future, as this can lead to unexpected behaviors.
+        return subprocess.run(app_args, cwd=context, capture_output=False).returncode

--- a/src/fprime/fpp/common.py
+++ b/src/fprime/fpp/common.py
@@ -150,6 +150,4 @@ class FppUtility(ExecutableAction):
         app_args = [self.utility] + user_args + input_args
         if builder.cmake.verbose:
             print(f"[FPP] '{' '.join(app_args)}'")
-        # NOTE: running in cwd=context because FPP behaves differently based on CWD (as of fpp v2.0.1)
-        # We may want to revisit in the future, as this can lead to unexpected behaviors.
         return subprocess.run(app_args, cwd=context, capture_output=False).returncode


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Running FppUtility.execute() in cwd=context.
Necessary because `fpp-to-cpp` will output relative include paths based on CWD at runtime

## Future Work

Consider whether this behavior from fpp-to-cpp should be reworked.
