### PR TITLE
Remove leak target

### DIFF
--- a/src/fprime/fbuild/target_definitions.py
+++ b/src/fprime/fbuild/target_definitions.py
@@ -40,14 +40,6 @@ check = BuildSystemTarget(
     build_type=BuildType.BUILD_TESTING,
     scope=TargetScope.BOTH,
 )
-BuildSystemTarget(
-    "check_leak",
-    mnemonic="check",
-    desc="Build and run unittests with memory leak checking",
-    flags={"leak"},
-    build_type=BuildType.BUILD_TESTING,
-    scope=TargetScope.BOTH,
-)
 GcovrTarget(
     check,
     mnemonic="check",

--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -153,12 +153,11 @@ Example:
   {EXECUTABLE} impl --ut
 
 """,
-    "check": f"""Run fprime unit tests with optional leak checking and test coverage.
+    "check": f"""Run fprime unit tests with optional test coverage.
 
 '{EXECUTABLE} check' handles the running of unit tests. It can be used on components to run the component's unit tests,
 deployments to run deployment unit tests, and with the '--all' flag to run all unit tests found in the build system.
-'{EXECUTABLE} check' implies the '--ut' flag and specifying it is redundant.  When '{EXECUTABLE} check' is run with the
-'--leak' flag, valgrind is used to look for resource leaks.
+'{EXECUTABLE} check' implies the '--ut' flag and specifying it is redundant.
 
 '{EXECUTABLE} check' can also be supplied the '--coverage' flag. When the '--coverage' flag is supplied, the unit test
 is run and 'gcovr' is run on the output to check coverage. The default flags to 'gcovr' are '--print-summary', '--txt',
@@ -174,17 +173,10 @@ Examples:
   cd Ref/SignalGen
   {EXECUTABLE} check
 
-  -- Run Ref/SignalGen Unit Tests With Leak Check --
-  cd Ref/SignalGen
-  {EXECUTABLE} check --leak
-
   -- Run Ref/SignalGen Unit Tests With Coverage --
   cd Ref/SignalGen
   {EXECUTABLE} check --coverage
 
-  -- Run Ref/SignalGen Unit Tests With Detailed HTML Coverage --
-  cd Ref/SignalGen
-  {EXECUTABLE} check --coverage
 """,
     "generate": f"""Generate build caches for the specified deployment
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removing --leak option as F´ core removed the `check_leak` target https://github.com/nasa/fprime/pull/2430
