### PR TITLE
Fix new project submodule update

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -32,6 +32,14 @@ subprocess.run(
         "https://github.com/nasa/fprime.git",
     ]
 )
+# Checkout F´ submodules (e.g. googletest)
+res = subprocess.run(
+    ["git", "submodule", "update", "--init", "--recursive"],
+    capture_output=True,
+)
+if res.returncode != 0:
+    print("[WARNING] Unable to initialize submodules. Functionality may be limited.")
+
 subprocess.run(
     ["git", "fetch", "origin", "--depth", "1", "tag", latest_tag_name],
     cwd="./fprime",
@@ -48,14 +56,6 @@ if res.returncode != 0:
     print(f"[ERROR] Unable to checkout tag: {latest_tag_name}. Exit...")
     sys.exit(1)  # sys.exit(1) indicates failure to cookiecutter
 
-# Checkout F´ submodules (e.g. googletest)
-res = subprocess.run(
-    ["git", "submodule", "update", "--init", "--recursive"],
-    cwd="./fprime",
-    capture_output=True,
-)
-if res.returncode != 0:
-    print("[WARNING] Unable to initialize submodules. Functionality may be limited.")
 
 # Install venv if requested
 if "{{cookiecutter.__install_venv}}" == "yes":

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/post_gen_project.py
@@ -48,9 +48,10 @@ if res.returncode != 0:
     print(f"[ERROR] Unable to checkout tag: {latest_tag_name}. Exit...")
     sys.exit(1)  # sys.exit(1) indicates failure to cookiecutter
 
-# Checkout submodules (e.g. googletest)
+# Checkout F´ submodules (e.g. googletest)
 res = subprocess.run(
     ["git", "submodule", "update", "--init", "--recursive"],
+    cwd="./fprime",
     capture_output=True,
 )
 if res.returncode != 0:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2484 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/2484

Running `git submodule update --init --recursive` in the new project was checking out `fprime/` back to `devel`. Running in `fprime/` fixes the bug and keeps the intended behavior of checking out F´'s submodule.
