### PR TITLE
Verify cookiecutter input for invalid characters

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/hooks/pre_gen_project.py
@@ -1,0 +1,8 @@
+from fprime.util.cookiecutter_wrapper import is_valid_name
+
+name = "{{ cookiecutter.deployment_name }}"
+
+if is_valid_name(name) != "valid":
+    raise ValueError(
+        f"Unacceptable deployment name: {name}. Do not use spaces or special characters"
+    )

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-module/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-module/hooks/pre_gen_project.py
@@ -1,0 +1,8 @@
+from fprime.util.cookiecutter_wrapper import is_valid_name
+
+name = "{{ cookiecutter.module_name }}"
+
+if is_valid_name(name) != "valid":
+    raise ValueError(
+        f"Unacceptable module name: {name}. Do not use spaces or special characters"
+    )

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-project/hooks/pre_gen_project.py
@@ -1,0 +1,8 @@
+from fprime.util.cookiecutter_wrapper import is_valid_name
+
+name = "{{ cookiecutter.project_name }}"
+
+if is_valid_name(name) != "valid":
+    raise ValueError(
+        f"Unacceptable project name: {name}. Do not use spaces or special characters"
+    )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes https://github.com/nasa/fprime/issues/2322 and https://github.com/nasa/fprime/issues/2505

## Rationale

Had a few users run into this issue, adding space to their project names.