### PR TITLE
Refactor build directory purging logic

### DIFF
--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -71,21 +71,27 @@ def run_fbuild_cli(
             print(
                 f"[INFO] {parsed.command.title()} build directory at: {purge_build.build_dir}"
             )
-            if parsed.force or confirm("Purge this directory?"):
-                purge_build.purge()
-            install_dir = purge_build.install_dest_exists()
-            if (
-                purge_build.build_type != BuildType.BUILD_CUSTOM
-                and install_dir
-                and install_dir.exists()
-            ):
-                print(
-                    f"[INFO] {parsed.command.title()} install directory at: {install_dir}"
-                )
-                if parsed.force or confirm(
-                    f"Purge installation directory at {install_dir} ?"
+            try:
+                if parsed.force or confirm("Purge this directory?"):
+                    purge_build.purge()
+                install_dir = purge_build.install_dest_exists()
+                if (
+                    purge_build.build_type != BuildType.BUILD_CUSTOM
+                    and install_dir
+                    and install_dir.exists()
                 ):
-                    purge_build.purge_install()
+                    print(
+                        f"[INFO] {parsed.command.title()} install directory at: {install_dir}"
+                    )
+                    if parsed.force or confirm(
+                        f"Purge installation directory at {install_dir} ?"
+                    ):
+                        purge_build.purge_install()
+            except PermissionError as e:
+                print(
+                    f"Error: Permission denied while purging {purge_build.build_dir}: {e}"
+                )
+
     else:
         target = get_target(parsed)
         option_args = {

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -405,7 +405,7 @@ class CMakeHandler:
 
         :param build_dir: build dir specified to purge
         """
-        shutil.rmtree(build_dir, ignore_errors=True)
+        shutil.rmtree(build_dir)
 
     def _read_values_from_cache(self, keys, build_dir):
         """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [2463](https://github.com/nasa/fprime/issues/2463) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This commit refactors the logic for purging the build directory in the `run_fbuild_cli` function. It now uses a `try-except` block to handle `PermissionError` exceptions when attempting to purge the build directory. 

## Rationale

Fixes Bug 

## Testing/Review Recommendations

For the testing I did a manual test, the procedure I followed was the following one:

1. Execute `fprime-util generate
2. Execute `fprime-util build`
3. Change a file to immutable e.g `sudo chattr +i build-fprime-automatic-native/lib/Linux/libFw_Buffer.a`
4. Execute `fprime-util purge`
5. The output shows which file cannot be removed as shown below.

```txt
[INFO] Purge build directory at: <path>/fprime/testv1/build-fprime-automatic-native
Purge this directory? (yes/no) [yes]: yes
Error: Permission denied while purging <path>/fprime/testprj/build-fprime-automatic-native: [Errno 1] Operation not permitted: 'libFw_Buffer.a'
```

## Future Work

Maybe unit tests, if necessary...

