### PR TITLE
CR 2375: TimeType.to_readable should display microsecond precision.

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -115,6 +115,7 @@ isdir
 isfile
 isinstance
 isnumeric
+isoformat
 Isr
 issubclass
 iterdir
@@ -246,6 +247,7 @@ testbuild
 testimpl
 textwrap
 timebase
+timespec
 toctree
 todo
 toolchain

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -289,7 +289,10 @@ class TimeType(type_base.BaseType):
 
         # If we could convert to a valid datetime, use that, otherwise, format
         if dt:
-            return dt.strftime("%Y-%m-%d %H:%M:%S%z")
+            # datetime.isoformat() returns time string with microsecond 
+            # precision.
+            # This line can be changed for other precisions or needs.
+            return dt.isoformat()
         return "%s: %d.%06ds, context=%d" % (
             TimeBase(self.__timeBase.val).name,
             self.__secs.val,

--- a/src/fprime/common/models/serialize/time_type.py
+++ b/src/fprime/common/models/serialize/time_type.py
@@ -289,10 +289,10 @@ class TimeType(type_base.BaseType):
 
         # If we could convert to a valid datetime, use that, otherwise, format
         if dt:
-            # datetime.isoformat() returns time string with microsecond 
+            # datetime.isoformat() returns time string with microsecond
             # precision.
             # This line can be changed for other precisions or needs.
-            return dt.isoformat()
+            return dt.isoformat(timespec="microseconds")
         return "%s: %d.%06ds, context=%d" % (
             TimeBase(self.__timeBase.val).name,
             self.__secs.val,

--- a/src/fprime/common/models/serialize/type_base.py
+++ b/src/fprime/common/models/serialize/type_base.py
@@ -4,6 +4,7 @@ Created on Dec 18, 2014
 @author: reder
 Replaced type base class with decorators
 """
+
 import abc
 
 from .type_exceptions import AbstractMethodException


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [2375](https://github.com/nasa/fprime/issues/2375) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n  |

---
## Change Description

This change makes the TimeType.to_readable function use datetime.isoformat to convert the datetime object to a human readable format. In doing so, fprime-gds outputs `channel.log` entries with microsecond precision.

## Rationale

> The fundamental philosophy that must be applied to the ground system is that any conversion (time, DN->EU, units, etc.) should never decrease the resolution of the source data.

## Testing/Review Recommendations

I tested the changes locally by first following the [fprime hello world](https://fprime-community.github.io/fprime-tutorial-hello-world/) tutorial. Then I installed the local version of fprime-tools, and ran the example project with `fprime-gds`. This produced the following output that I've attached below showing no more accuracy loss in `channel.log`:

![image](https://github.com/fprime-community/fprime-tools/assets/5873587/e40f94b1-76bf-46a7-8aad-16abddc1bcc2)

Compared with before this change:

![image](https://github.com/fprime-community/fprime-tools/assets/5873587/591712d0-118f-4c5c-93b7-31071aafc3b4)

## Future Work

This seems like too a small change to make a unit test for, but I could think of a good way to design one if requested.
