### PR TITLE
Fix for forced purge on non existing directories

### DIFF
--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -77,11 +77,13 @@ def run_fbuild_cli(
                     if Path(purge_build.build_dir).is_dir():
                         perform_purge = True
                     else:
-                        print(f"[WARNING] Skipping purge. The following directory does not exist: {purge_build.build_dir}")
+                        print(
+                            f"[WARNING] Skipping purge. The following directory does not exist: {purge_build.build_dir}"
+                        )
                 else:
                     perform_purge = confirm("Purge this directory?")
 
-                if (perform_purge):
+                if perform_purge:
                     purge_build.purge()
 
                 install_dir = purge_build.install_dest_exists()

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -78,7 +78,7 @@ def run_fbuild_cli(
                         perform_purge = True
                     else:
                         print(
-                            f"[WARNING] Skipping purge. The following directory does not exist: {purge_build.build_dir}"
+                            f"[INFO] Skipping purge. The following directory does not exist: {purge_build.build_dir}"
                         )
                 else:
                     perform_purge = confirm("Purge this directory?")

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -72,8 +72,18 @@ def run_fbuild_cli(
                 f"[INFO] {parsed.command.title()} build directory at: {purge_build.build_dir}"
             )
             try:
-                if parsed.force or confirm("Purge this directory?"):
+                perform_purge = False
+                if parsed.force:
+                    if Path(purge_build.build_dir).is_dir():
+                        perform_purge = True
+                    else:
+                        print(f"[WARNING] Skipping purge. The following directory does not exist: {purge_build.build_dir}")
+                else:
+                    perform_purge = confirm("Purge this directory?")
+
+                if (perform_purge):
                     purge_build.purge()
+
                 install_dir = purge_build.install_dest_exists()
                 if (
                     purge_build.build_type != BuildType.BUILD_CUSTOM


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Change the behavior of `fprime-util purge -f` when a build folder does not exists.

## Rationale

The current `fprime-util purge -f` command fails if the build directory does not exist.

That leads to situations where the `build-fprime-automatic-native-ut` directory exists and could be deleted, but since the `build-fprime-automatic-native` directory does not exists, the command fails and the UT directory is not deleted.

Previous behavior when only the UT folder exists:
```
fprime-util purge -f
[WARNING] /home/fprime/settings.ini does not exist
[WARNING] /home/fprime/settings.ini does not exist
[WARNING] /home/fprime/settings.ini does not exist
[INFO] Purge build directory at: /home/fprime/build-fprime-automatic-native
[ERROR] [Errno 2] No such file or directory: '/home/fprime/build-fprime-automatic-native'
```

New behavior when only the UT folder exists:
```
fprime-util purge -f
[WARNING] /home/fprime/settings.ini does not exist
[WARNING] /home/fprime/settings.ini does not exist
[WARNING] /home/fprime/settings.ini does not exist
[INFO] Purge build directory at: /home/fprime/build-fprime-automatic-native
[WARNING] Skipping purge. The following directory does not exist: /home/fprime/build-fprime-automatic-native
[INFO] Purge build directory at: /home/fprime/build-fprime-automatic-native-ut
```

Note: I tried to implement it by changing the behavior of the `build.load` function, using the `skip_validation` parameter, without success, since it is also set as `true` in other places for the purge function where the function should not raise an error. 