### PR TITLE
minor: Deployment template comments

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -145,7 +145,7 @@ void setupTopology(const TopologyState& state) {
     connectComponents();
     // Autocoded command registration. Function provided by autocoder.
     regCommands();
-    // Project-specific component configuration. Function provided above. May be inlined, if desired.
+    // Deployment-specific component configuration. Function provided above. May be inlined, if desired.
     configureTopology();
     // Autocoded parameter loading. Function provided by autocoder.
     // loadParameters();

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/cookiecutter.json
@@ -1,0 +1,7 @@
+{
+    "subtopology_name": "MySubtopology",
+    "__subtopology_name_upper": "{{cookiecutter.subtopology_name.upper()}}",
+    "__prompts__": {
+        "st_name": "Subtopology name"
+    }
+}

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/hooks/pre_gen_project.py
@@ -1,0 +1,8 @@
+from fprime.util.cookiecutter_wrapper import is_valid_name
+
+name = "{{ cookiecutter.subtopology_name }}"
+
+if is_valid_name(name) != "valid":
+    raise ValueError(
+        f"Unacceptable project name: {name}. Do not use spaces or special characters"
+    )

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCE_FILES
+    "${CMAKE_CURRENT_LIST_DIR}/{{cookiecutter.subtopology_name}}.fpp"
+)
+
+register_fprime_module()

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/TODO.md
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/TODO.md
@@ -1,0 +1,22 @@
+# {{cookiecutter.subtopology_name}} - F' Subtopology
+
+The starter files for the subtopology have been generated. To fully integrate it into your project, you need to do the following steps:
+
+1. Add the `{{cookiecutter.subtopology_name}}/` folder to its parent directory's `CMakeLists` file:
+
+```cmake
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/{{cookiecutter.subtopology_name}}/")
+set(MOD_DEPS ${FPRIME_CURRENT_MODULE}/{{cookiecutter.subtopology_name}})
+```
+
+2. Add (and configure) `TopologyConfig.hpp` in `fprime/config`, or wherever your F' config folder resides. This file should include the following:
+
+```cpp
+#ifndef TOPOLOGYCONFIG_HPP
+#define TOPOLOGYCONFIG_HPP
+
+#include <<DeploymentName>/Top/<DeploymentName>TopologyAc.hpp> // name of deployment using subtopology
+using namespace <DeploymentNamespace>; // namespace of deployment using subtopology
+
+#endif
+```

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.cmake
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.cmake
@@ -1,0 +1,8 @@
+list(APPEND MOD_DEPS
+    Fw/Logger
+    # Add other dependencies as necessary
+)
+
+list(APPEND SOURCE_FILES
+    "${CMAKE_CURRENT_LIST_DIR}/{{cookiecutter.subtopology_name}}.cpp"
+)

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.cpp
@@ -1,0 +1,21 @@
+#include <{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.hpp>
+// TODO: include the necessary header files for the subtopology
+// this may need to be modified with the correct path depending on the parent folder of your subtopology
+#include <{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}TopologyAc.hpp>
+
+namespace {{cookiecutter.subtopology_name}}
+{
+    void configureTopology(const TopologyState &state) {
+        // TODO: Add configuration code here
+    }
+
+    void startTopology(const TopologyState &state) {
+        // TODO: Add start code here
+    }
+
+    void teardownTopology(const TopologyState &state) {
+        // TODO: Add teardown code here
+    }
+}
+
+// GNJ7BBP73WE9

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.cpp
@@ -17,5 +17,3 @@ namespace {{cookiecutter.subtopology_name}}
         // TODO: Add teardown code here
     }
 }
-
-// GNJ7BBP73WE9

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.fpp
@@ -1,0 +1,21 @@
+module {{cookiecutter.subtopology_name}} {
+    module Defaults {
+        constant QUEUE_SIZE = 10
+        constant STACK_SIZE = 64 * 1024
+    }
+
+    # include any instance definitions here. For example:
+    # instance framer: Svc.Framer base id 0x4100
+
+    topology {{cookiecutter.subtopology_name}} {
+
+        # include any instance declarations here
+        # and wiring connections as well. For example:
+
+        # instance framer
+        # connections Framer {
+        #     ...    
+        # }
+
+    } # end topology
+} # end {{cookiecutter.subtopology_name}}

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}.hpp
@@ -1,0 +1,15 @@
+#ifndef {{cookiecutter.__subtopology_name_upper}}_HPP
+#define {{cookiecutter.__subtopology_name_upper}}_HPP
+
+#include "{{cookiecutter.subtopology_name}}TopologyDefs.hpp"
+// TODO: Read TODO.md for setting up the TopologyConfig.hpp file
+#include <TopologyConfig.hpp>
+
+
+namespace {{cookiecutter.subtopology_name}} {
+    void configureTopology(const TopologyState& state);
+    void startTopology(const TopologyState& state);
+    void teardownTopology(const TopologyState& state);
+}
+
+#endif

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}TopologyDefs.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}TopologyDefs.hpp
@@ -1,0 +1,27 @@
+#ifndef {{cookiecutter.__subtopology_name_upper}}_DEFS_HPP
+#define {{cookiecutter.__subtopology_name_upper}}_DEFS_HPP
+
+namespace {{cookiecutter.subtopology_name}} {
+    struct TopologyState {
+        /* include any variables that are needed for 
+        configuring/starting/tearing down the topology */
+    };
+}
+
+namespace GlobalDefs {
+    namespace PingEntries {
+        /* include any ping entries that are needed for the subtopology
+        e.g., rate groups need FAIL and WARN ping enums
+        For example:
+
+        namespace {{cookiecutter.subtopology_name}}_rateGroup {
+            enum {
+                WARN = 3,
+                FATAL = 5
+            };
+        }
+        */
+    }
+}
+
+#endif

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -180,6 +180,13 @@ def add_special_parsers(
         dest="new_project",
         help="Generate a new project",
     )
+    new_exclusive.add_argument(
+        "--subtopology",
+        default=False,
+        action="store_true",
+        dest="new_subtopology",
+        help="Generate a new subtopology",
+    )
 
     # Code formatting with clang-format
     format_parser = subparsers.add_parser(

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -24,6 +24,7 @@ from fprime.util.cookiecutter_wrapper import (
     new_deployment,
     new_module,
     new_project,
+    new_subtopology
 )
 
 
@@ -138,6 +139,8 @@ def run_new(
         return new_module(build, parsed)
     if parsed.new_project:
         return new_project(parsed)
+    if parsed.new_subtopology:
+        return new_subtopology(build, parsed)
     raise NotImplementedError(
         "`fprime-util new` target is missing or not implemented. See usage (--help)."
     )

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -188,6 +188,47 @@ def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
     print(f"[INFO] New deployment successfully created: {gen_path}")
     return 0
 
+def new_subtopology(build: Build, parsed_args: "argparse.Namespace"):
+    """Creates a new subtopolgy using cookiecutter"""
+    # Checks if subtopology_cookiecutter is set in settings.ini file, else uses local install template as default
+    if (
+        build.get_settings("subtopology_cookiecutter", None) is not None
+        and build.get_settings("subtopology_cookiecutter", None) != "default"
+    ):
+        source = build.get_settings("subtopology_cookiecutter", None)
+        print(f"[INFO] Cookiecutter source: {source}")
+    else:
+        source = (
+            os.path.dirname(__file__)
+            + "/../cookiecutter_templates/cookiecutter-fprime-subtopology"
+        )
+        print("[INFO] Cookiecutter: using builtin template for new subtopology")
+    try:
+        gen_path = Path(
+            cookiecutter(source, overwrite_if_exists=parsed_args.overwrite)
+        ).resolve()
+        # Attempt to register to CMakeLists.txt or project.cmake
+        register_with_cmake(
+            gen_path,
+            Path(build.get_settings("project_root", None)).resolve(),
+            build.cmake_root,
+        )
+
+    except OutputDirExistsException as out_directory_error:
+        print(
+            f"{out_directory_error}. Use --overwrite to overwrite (will not delete non-generated files).",
+            file=sys.stderr,
+        )
+        return 1
+    except FileNotFoundError as e:
+        print(
+            f"{e}. Permission denied to write to the directory.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"[INFO] New subtopology successfully created: {gen_path}")
+    return 0
+
 
 def new_module(build: Build, parsed_args: "argparse.Namespace"):
     """Creates a new F' project"""

--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -292,6 +292,8 @@ Usage:
   Generate a new F' component within a F' project. This command prompts for what type of component and what it should
   include. At the end of the generation, the user can chose to automatically add the component to the build system and
   run the implementation generator.
+  -- New Subtopology --
+  Generate a new F' subtopology. This command prompts for the name of the subtopology, and outputs a folder containing the structure for one. The user can then add the subtopology to their own project depending on where the subtopology is generated.
 """,
     "format": f"""Format C/C++ files using clang-format
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

I noticed a very minor issue with a comment in the deployment template. `configureTopology()` should be noted is deployment-specific, not project-specific.