### PR TITLE
Uncomment noop functions from topology template

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -147,8 +147,10 @@ void setupTopology(const TopologyState& state) {
     regCommands();
     // Project-specific component configuration. Function provided above. May be inlined, if desired.
     configureTopology();
+    // Component-specific configurations using fpp phases. Function provided by autocoder.
+    configComponents(state);
     // Autocoded parameter loading. Function provided by autocoder.
-    // loadParameters();
+    loadParameters();
     // Autocoded task kick-off (active components). Function provided by autocoder.
     startTasks(state);
 {%- if (cookiecutter.com_driver_type in ["TcpServer", "TcpClient"]) %}


### PR DESCRIPTION
Uncomment parameters call (ac) and include config components for phases (both noops out of the box)

| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2774  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Certain functions (i.e. `loadParameters`) are now noops within F Prime. However, they are commented out of the box in the topology template files, which is inconvenient. They are now uncommented.