### PR TITLE
Swap `regCommands()` and `configTopology` + Move Buffmgr and Framing setup to front

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -84,6 +84,21 @@ Svc::Health::PingEntry pingEntries[] = {
  * desired, but is extracted here for clarity.
  */
 void configureTopology() {
+    // Buffer managers need a configured set of buckets and an allocator used to allocate memory for those buckets.
+    Svc::BufferManager::BufferBins upBuffMgrBins;
+    memset(&upBuffMgrBins, 0, sizeof(upBuffMgrBins));
+    upBuffMgrBins.bins[0].bufferSize = FRAMER_BUFFER_SIZE;
+    upBuffMgrBins.bins[0].numBuffers = FRAMER_BUFFER_COUNT;
+    upBuffMgrBins.bins[1].bufferSize = DEFRAMER_BUFFER_SIZE;
+    upBuffMgrBins.bins[1].numBuffers = DEFRAMER_BUFFER_COUNT;
+    upBuffMgrBins.bins[2].bufferSize = COM_DRIVER_BUFFER_SIZE;
+    upBuffMgrBins.bins[2].numBuffers = COM_DRIVER_BUFFER_COUNT;
+    bufferManager.setup(BUFFER_MANAGER_ID, 0, mallocator, upBuffMgrBins);
+
+    // Framer and Deframer components need to be passed a protocol handler
+    framer.setup(framing);
+    deframer.setup(deframing);
+
     // Command sequencer needs to allocate memory to hold contents of command sequences
     cmdSeq.allocateBuffer(0, mallocator, CMD_SEQ_BUFFER_SIZE);
 
@@ -105,21 +120,6 @@ void configureTopology() {
 
     // Health is supplied a set of ping entires.
     health.setPingEntries(pingEntries, FW_NUM_ARRAY_ELEMENTS(pingEntries), HEALTH_WATCHDOG_CODE);
-
-    // Buffer managers need a configured set of buckets and an allocator used to allocate memory for those buckets.
-    Svc::BufferManager::BufferBins upBuffMgrBins;
-    memset(&upBuffMgrBins, 0, sizeof(upBuffMgrBins));
-    upBuffMgrBins.bins[0].bufferSize = FRAMER_BUFFER_SIZE;
-    upBuffMgrBins.bins[0].numBuffers = FRAMER_BUFFER_COUNT;
-    upBuffMgrBins.bins[1].bufferSize = DEFRAMER_BUFFER_SIZE;
-    upBuffMgrBins.bins[1].numBuffers = DEFRAMER_BUFFER_COUNT;
-    upBuffMgrBins.bins[2].bufferSize = COM_DRIVER_BUFFER_SIZE;
-    upBuffMgrBins.bins[2].numBuffers = COM_DRIVER_BUFFER_COUNT;
-    bufferManager.setup(BUFFER_MANAGER_ID, 0, mallocator, upBuffMgrBins);
-
-    // Framer and Deframer components need to be passed a protocol handler
-    framer.setup(framing);
-    deframer.setup(deframing);
 
     // Note: Uncomment when using Svc:TlmPacketizer
     // tlmSend.setPacketList({{cookiecutter.deployment_name}}PacketsPkts, {{cookiecutter.deployment_name}}PacketsIgnore, 1);
@@ -143,10 +143,10 @@ void setupTopology(const TopologyState& state) {
     setBaseIds();
     // Autocoded connection wiring. Function provided by autocoder.
     connectComponents();
-    // Autocoded command registration. Function provided by autocoder.
-    regCommands();
     // Deployment-specific component configuration. Function provided above. May be inlined, if desired.
     configureTopology();
+    // Autocoded command registration. Function provided by autocoder.
+    regCommands();
     // Component-specific configurations using fpp phases. Function provided by autocoder.
     configComponents(state);
     // Autocoded parameter loading. Function provided by autocoder.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#2791 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Swap `regCommands()` and `configureTopology()` in Topology.cpp
Move BufferManager Setup and Framing/Deframing setup to front in `configureTopology()` in Topology.cpp

## Rationale
* Registering commands also generates events as a byproduct. In a hub pattern implementation connected to eventLogging, the hub will assert since it tries to handle the events before `configureTopology()` is called (and the bufferManager is not setup).
* There may be other similar implementations from other projects that require a more specific setup before their components are ready to handle commands and events.
* Have not found a use case to handle commands before the system setup is completed.


* BufferManager and Framing/Deframing should be setup before `readParamFile()` is called. This also sends an event and the hub would assert before the bufferManager and deframer is setup.


## Testing/Review Recommendations

CI to ensure standard projects are working correctly

CC: @timcanham @LeStarch @bocchino @Joshua-Anderson

