### PR TITLE
added dash to list of invalid characters

### DIFF
--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -333,6 +333,7 @@ def is_valid_name(word: str):
         "`",
         "|",
         "=",
+        "-",
     ]
     for char in invalid_characters:
         if isinstance(word, str) and char in word:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2802 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This change just adds the `-` character to the list of invalid characters in the `is_valid_name` function.

## Rationale

This fixes an issue encountered when a component name has a `-` in it.

## Testing/Review Recommendations

Once unit tests are written for the util functions, one could add a unit test that verifies a name with the `-` is considered invalid.

## Future Work

NA
