### PR TITLE
prettyprinting: Remove excess indent

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
@@ -4,11 +4,11 @@ module {{cookiecutter.deployment_name}} {
   # Symbolic constants for port numbers
   # ----------------------------------------------------------------------
 
-    enum Ports_RateGroups {
-      rateGroup1
-      rateGroup2
-      rateGroup3
-    }
+  enum Ports_RateGroups {
+    rateGroup1
+    rateGroup2
+    rateGroup3
+  }
 
   topology {{cookiecutter.deployment_name}} {
 


### PR DESCRIPTION
There is an excess indent in the cookiecutter file for topology.fpp 😁 