### PR TITLE
Update function calls for comDriver headers

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[]) {
 
     // Setup, cycle, and teardown topology
     {{cookiecutter.deployment_name}}::setupTopology(inputs);
-    {{cookiecutter.deployment_name}}::startSimulatedCycle(1000);  // Program loop cycling rate groups at 1Hz
+    {{cookiecutter.deployment_name}}::startSimulatedCycle(Fw::Time(1,0));  // Program loop cycling rate groups at 1Hz
     {{cookiecutter.deployment_name}}::teardownTopology(inputs);
     (void)printf("Exiting...\n");
     return 0;

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -159,7 +159,7 @@ void setupTopology(const TopologyState& state) {
         Os::TaskString name("ReceiveTask");
         // Uplink is configured for receive so a socket task is started
         comDriver.configure(state.hostname, state.port);
-        comDriver.startSocketTask(name, true, COMM_PRIORITY, Default::STACK_SIZE);
+        comDriver.start(name, true, COMM_PRIORITY, Default::STACK_SIZE);
     }
 {%- elif cookiecutter.com_driver_type == "UART" %}
     if (state.uartDevice != nullptr) {
@@ -167,7 +167,7 @@ void setupTopology(const TopologyState& state) {
         // Uplink is configured for receive so a socket task is started
         if (comDriver.open(state.uartDevice, static_cast<Drv::LinuxUartDriver::UartBaudRate>(state.baudRate), 
                            Drv::LinuxUartDriver::NO_FLOW, Drv::LinuxUartDriver::PARITY_NONE, Svc::DeframerCfg::RING_BUFFER_SIZE)) {
-            comDriver.startReadThread(COMM_PRIORITY, Default::STACK_SIZE);
+            comDriver.start(COMM_PRIORITY, Default::STACK_SIZE);
         } else {
             printf("Failed to open UART device %s at baud rate %" PRIu32 "\n", state.uartDevice, state.baudRate);
         }
@@ -179,7 +179,7 @@ void setupTopology(const TopologyState& state) {
 Os::Mutex cycleLock;
 volatile bool cycleFlag = true;
 
-void startSimulatedCycle(U32 milliseconds) {
+void startSimulatedCycle(Fw::Time interval) {
     cycleLock.lock();
     bool cycling = cycleFlag;
     cycleLock.unLock();
@@ -187,7 +187,7 @@ void startSimulatedCycle(U32 milliseconds) {
     // Main loop
     while (cycling) {
         {{cookiecutter.deployment_name}}::blockDrv.callIsr();
-        Os::Task::delay(milliseconds);
+        Os::Task::delay(interval);
 
         cycleLock.lock();
         cycling = cycleFlag;
@@ -209,10 +209,10 @@ void teardownTopology(const TopologyState& state) {
     // Other task clean-up.
 {%- if cookiecutter.com_driver_type == "UART" %}
     comDriver.quitReadThread();
-    (void)comDriver.join(nullptr);
+    (void)comDriver.join();
 {%- else %}
-    comDriver.stopSocketTask();
-    (void)comDriver.joinSocketTask(nullptr);
+    comDriver.stop();
+    (void)comDriver.join();
 {%- endif %}
 
     // Resource deallocation

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
@@ -73,7 +73,7 @@ void teardownTopology(const TopologyState& state);
  *
  * \param milliseconds: milliseconds to delay for each cycle. Default: 1000 or 1Hz.
  */
-void startSimulatedCycle(U32 milliseconds = 1000);
+void startSimulatedCycle(Fw::Time interval = Fw::Time(1,0));
 
 /**
  * \brief stop the simulated cycle started by startSimulatedCycle


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#2672 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This PR updates the function calls for the com driver on a new deployment.
This should be used for an upcoming F-prime 3.4.4 (or anything after 3.4.3).

## Rationale

nasa/fprime#2672 updates the function calls for com drivers, such as SocketReadTask, Linux Uart, etc..
A new deployment using the devel fprime branch will fail upon building, since the headers do not match.
This change matches the cookie cutter with the updated function headers.

CC @timcanham @LeStarch
