### PR TITLE
Remove restrictions for the Build class to setup its platform

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -72,8 +72,8 @@ class Build:
     def invent(self, platform: str = None, build_dir: Path = None):
         """Invents a build path from a given platform
 
-        Sets this build up as a new build that would be used as as part of a generate step. This directory must not
-        already exist. If platform is None, a default will be chosen from the settings.ini file. If the settings.ini
+        Sets this build up as a new build that would be used as as part of a generate step.
+        If platform is None, a default will be chosen from the settings.ini file. If the settings.ini
         file does not exist, or does not specify a default_toolchain, then "native" will be used. Settings are loaded in
         this step for further uses of this build.
 
@@ -84,14 +84,8 @@ class Build:
             platform:   name of platform to build against. None will use default from settings.ini or without this
                         setting, "native". Defaults to None.
             build_dir:  explicitly sets the build path to allow for user override of default
-
-        Raises:
-            InvalidBuildCacheException: a build cache already exists as it should not
         """
         self.__setup_default(platform, build_dir)
-        if self.build_dir.exists():
-            msg = f"{self.build_dir} already exists."
-            raise InvalidBuildCacheException(msg)
 
     def load(self, platform: str = None, build_dir: Path = None, skip_validation=False):
         """Load an existing build cache
@@ -519,10 +513,6 @@ class Build:
                         setting, "native". Defaults to None.
             build_dir:  explicitly sets the build path to allow for user override of default
         """
-        assert self.settings is None, "Already setup it is invalid to re-setup"
-        assert self.platform is None, "Already setup it is invalid to re-setup"
-        assert self.build_dir is None, "Already setup it is invalid to re-setup"
-
         self.settings = IniSettings.load(
             self.cmake_root / "settings.ini",
             platform,

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -194,3 +194,17 @@ def test_find_nearest_parent_project():
         else:
             with pytest.raises(fprime.fbuild.builder.UnableToDetectProjectException):
                 fprime.fbuild.builder.Build.find_nearest_parent_project(path)
+
+def test_build_invent_twice():
+    """
+    Test that the Build.invent can be called twice
+    """
+    local = pathlib.Path(os.path.dirname(__file__))
+    dep_dir = local / "cmake-data" / "testbuild"
+    builder = fprime.fbuild.builder.Build(
+        fprime.fbuild.builder.BuildType.BUILD_NORMAL, dep_dir
+    )
+
+    # No exception should be raised here.
+    builder.invent()
+    builder.invent()

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -195,6 +195,7 @@ def test_find_nearest_parent_project():
             with pytest.raises(fprime.fbuild.builder.UnableToDetectProjectException):
                 fprime.fbuild.builder.Build.find_nearest_parent_project(path)
 
+
 def test_build_invent_twice():
     """
     Test that the Build.invent can be called twice


### PR DESCRIPTION
Which allows users to call fprime-util generate several times without faiure

| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2869 |
|**_Has Unit Tests (y/n)_**|  yes |
|**_Documentation Included (y/n)_**| yes |

---
## Change Description

Removes restrictions on calling Build.invent and Build.__setup_default more than once. I admit I don't understand the full implications of this, so I'd encourage the author @LeStarch to evaluate whether this breaks things. Anecdotally, locally installing this allows me to call generate in my fprime project several times without error.

## Rationale

Fixes a (perceived) bug that fprime-util generate should not fail if a cache already exists

## Testing/Review Recommendations

There is a very simple included unit test that shows that calling Builder.invent() twice does not raise an assertion. Please let me know what else I need to test.
