### PR TITLE
Allow empty new component

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/pre_gen_project.py
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/hooks/pre_gen_project.py
@@ -1,22 +1,7 @@
 from fprime.util.cookiecutter_wrapper import is_valid_name
 
-
-# Check to ensure Component Name is valid
-def verify_inputs(component_name, commands, events, telemetry, parameters):
-    if is_valid_name(component_name) != "valid":
-        raise ValueError(
-            "Unacceptable component name. Do not use spaces or special characters"
-        )
-    if commands == "no" and events == "no" and telemetry == "no" and parameters == "no":
-        raise ValueError(
-            "[ERROR] You must select at least one of the following options to have in your component: commands, events, telemetry, parameters"
-        )
-
-
-verify_inputs(
-    "{{ cookiecutter.component_name }}",
-    "{{ cookiecutter.enable_commands }}",
-    "{{ cookiecutter.enable_events }}",
-    "{{ cookiecutter.enable_telemetry }}",
-    "{{ cookiecutter.enable_parameters }}",
-)
+# Check if the component name is valid
+if is_valid_name("{{ cookiecutter.component_name }}") != "valid":
+    raise ValueError(
+        "Unacceptable component name. Do not use spaces or special characters"
+    )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Allow component with no command/event/telem/parameter

## Rationale

Fix https://github.com/nasa/fprime/issues/2928