### PR TITLE
Update Cheetah3 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "Markdown>=3.3.4",
     "pexpect>=4.8.0",
     "pytest>=6.2.4",
-    "Cheetah3>=3.2.6",
+    "CT3>=3.3.3",
     "cookiecutter>=2.2.3",
     "gcovr>=6.0",
     "urllib3<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "Markdown>=3.3.4",
     "pexpect>=4.8.0",
     "pytest>=6.2.4",
-    "CT3>=3.3.3",
     "cookiecutter>=2.2.3",
     "gcovr>=6.0",
     "urllib3<2.0.0",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removes `Cheetah3` dependency and adds in the new package name `CT3`. Same package, different pypi target.

`pip install fprime-tools` installs Cheetah3 even if CT3 is already installed, because pip doesn't recognize them to be the same packages

```
$ pip freeze | grep C                                                                                                                                                                                                                            
Cheetah3==3.2.6.post1
CT3==3.3.3.post1
```
