### PR TITLE
Fix attestation problems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,5 +29,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Clean-Up Attestations
+        run: rm dist/*.attestation
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The publish pypa Github action used to publish our packages started producing attestation files on publish. However, the underlying tools balk at these files (currently). This removes these files between our two publishing steps.

Note: this work can be undone once `twine` is released to ignore these files. 