### PR TITLE
Fixing sanitizer handling. Fixes nasa/fprime#2678

### DIFF
--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -57,11 +57,11 @@ def run_fbuild_cli(
         toolchain = build.find_toolchain()
         print(f"[INFO] Generating build directory at: {build.build_dir}")
         print(f"[INFO] Using toolchain file {toolchain} for platform {parsed.platform}")
-        if parsed.ut and not parsed.disable_sanitizers:
+        if parsed.disable_sanitizers:
             # The following options are defined in F' to have CMake enable the sanitizers
-            cmake_args["ENABLE_SANITIZER_LEAK"] = "ON"
-            cmake_args["ENABLE_SANITIZER_ADDRESS"] = "ON"
-            cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = "ON"
+            cmake_args["ENABLE_SANITIZER_LEAK"] = "OFF"
+            cmake_args["ENABLE_SANITIZER_ADDRESS"] = "OFF"
+            cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = "OFF"
         if toolchain is not None:
             cmake_args["CMAKE_TOOLCHAIN_FILE"] = toolchain
         if parsed.ninja:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This fixes nasa/fprime#2678.  Essentially, the presence of the disable sanitizer flag should disable the sanitizers. In other cases, the sanitizer handling should be left to the underlying fprime/CMake implementation.