### PR TITLE
Adding --target flag to build CMake target by name

### DIFF
--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -12,7 +12,7 @@ from typing import Callable, Dict, List, Tuple
 
 from fprime.common.utils import confirm
 from fprime.fbuild.builder import Build
-from fprime.fbuild.target import Target
+from fprime.fbuild.target import Target, DesignateTargetAction
 from fprime.fbuild.types import BuildType
 
 
@@ -180,12 +180,23 @@ def add_target_parser(
             if target.allows_pass_args()
             else ""
         )
-        parser.add_argument(
-            f"--{flag}",
-            action="store_true",
-            default=False,
-            help=f"{target.desc}{extra_help}",
-        )
+        # Target flag special handling
+        if flag == "target":
+            parser.add_argument(
+                f"--target",
+                type=str,
+                action=DesignateTargetAction,
+                default=None,
+                nargs=1,
+                help=f"{target.desc}",
+            )
+        else:
+            parser.add_argument(
+                f"--{flag}",
+                action="store_true",
+                default=False,
+                help=f"{target.desc}{extra_help}",
+            )
     for flag, description in filter(
         lambda flag_desc: flag_desc[0] not in flags, target.option_args()
     ):

--- a/src/fprime/fbuild/target_definitions.py
+++ b/src/fprime/fbuild/target_definitions.py
@@ -6,7 +6,7 @@ as such, each target need only be instantiated but need not be assigned to anyth
 """
 
 from .gcovr import GcovrTarget
-from .target import BuildSystemTarget, TargetScope
+from .target import BuildSystemTarget, DesignatedBuildSystemTarget, TargetScope
 from .types import BuildType
 
 #### "build" targets for components, deployments, unittests for both normal and testing builds ####
@@ -27,9 +27,26 @@ BuildSystemTarget(
 BuildSystemTarget(
     "all",
     mnemonic="build",
-    desc="Build components, ports, UTs, and deployments for unittest build",
+    desc="Build all components, ports, UTs, and deployments for unittest build",
     scope=TargetScope.GLOBAL,
     flags={"all", "ut"},
+    build_type=BuildType.BUILD_TESTING,
+)
+
+DesignatedBuildSystemTarget(
+    "target",
+    mnemonic="build",
+    desc="Build a specific CMake target by name",
+    scope=TargetScope.GLOBAL,
+    flags={"target"},
+)
+
+DesignatedBuildSystemTarget(
+    "target",
+    mnemonic="build",
+    desc="Build a specific CMake target by name using the UT build",
+    scope=TargetScope.GLOBAL,
+    flags={"ut", "target"},
     build_type=BuildType.BUILD_TESTING,
 )
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime-tools/pull/228 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Allows `fprime-util build --target target` to specifically call out a target to build!