### PR TITLE
Add location check to fprime-util new --deployment and --component

### DIFF
--- a/src/fprime/common/utils.py
+++ b/src/fprime/common/utils.py
@@ -26,3 +26,29 @@ def replace_contents(filename, what, replacement, count=1):
         new_file = changelog.replace(what, replacement, count)
         fh.write(new_file)
         return new_file != changelog
+
+
+def check_path_is_within_fprime_module(path: Path):
+    """Check if the current working directory is within an F prime module
+
+    This is done by checking if any line in the path/CMakeLists.txt file starts
+    with register_fprime_*
+
+    This is useful to prevent users from running commands in the wrong location.
+
+    Returns:
+        bool: True if the path is within an F prime module, False otherwise
+    """
+
+    if not Path(path / "CMakeLists.txt").exists():
+        return False
+
+    with open(path / "CMakeLists.txt") as cmake_file:
+        lines = cmake_file.readlines()
+
+    # Looks for line "register_fprime_*" in CMakeLists.txt
+    statement = "register_fprime_"
+    for line in lines:
+        if line.startswith(statement):
+            return True
+    return False

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -148,6 +148,12 @@ def add_special_parsers(
         action="store_true",
         help="Prevent updating the virtual environment during project creation",
     )
+    new_parser.add_argument(
+        "--force",
+        default=False,
+        action="store_true",
+        help="Override warning about creating new deployment or component within a deployment or component",
+    )
     new_exclusive = new_parser.add_argument_group(
         "'new' targets"
     ).add_mutually_exclusive_group()

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -3,7 +3,6 @@
 
 import glob
 import os
-import shutil
 import sys
 
 from typing import TYPE_CHECKING
@@ -13,7 +12,7 @@ from pathlib import Path
 from cookiecutter.exceptions import OutputDirExistsException
 from cookiecutter.main import cookiecutter
 
-from fprime.common.utils import confirm
+from fprime.common.utils import confirm, check_path_is_within_fprime_module
 from fprime.fbuild.builder import Build
 from fprime.fbuild.cmake import CMakeExecutionException
 from fprime.fpp.impl import fpp_generate_implementation
@@ -88,6 +87,14 @@ def find_nearest_cmake_file(component_dir: Path, cmake_root: Path, proj_root: Pa
 
 def new_component(build: Build, parsed_args: "argparse.Namespace"):
     """Uses cookiecutter for making new components"""
+
+    if check_path_is_within_fprime_module(Path.cwd()) and not parsed_args.force:
+        print(
+            "[ERROR] Wrong location. Cannot create component within an existing component or deployment."
+            " Use --force to override."
+        )
+        return 1
+
     try:
         proj_root = build.get_settings("project_root", None)
 
@@ -149,6 +156,13 @@ def new_component(build: Build, parsed_args: "argparse.Namespace"):
 
 def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
     """Creates a new deployment using cookiecutter"""
+
+    if check_path_is_within_fprime_module(Path.cwd()) and not parsed_args.force:
+        print(
+            "[ERROR] Wrong location. Cannot create deployment within an existing component or deployment"
+        )
+        return 1
+
     # Checks if deployment_cookiecutter is set in settings.ini file, else uses local install template as default
     if (
         build.get_settings("deployment_cookiecutter", None) is not None


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#2971 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Adds a feature to check the current directory fprime-util new is being run in for the component and deployment tags. Warns and blocks if current directory is a component or deployment directory by way of checking CMakeLists.txt file for a statement of the form "register_fprime_*". Allows for the use of the --force to override warning.

## Rationale

This is meant to address issue #2971 on the main fprime repository

## Testing/Review Recommendations

Review warning message text. Determine if requiring --force is the desired behavior.
