### PR TITLE
Fix coverage --test-ac option and update CMake file comments

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/CMakeLists.txt
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-component/{{cookiecutter.component_name}}/CMakeLists.txt
@@ -6,7 +6,7 @@
 # UT_SOURCE_FILES: list of source files for unit tests
 #
 # More information in the F´ CMake API documentation:
-# https://fprime.jpl.nasa.gov/latest/documentation/reference
+# https://fprime.jpl.nasa.gov/latest/docs/user-manual/build-system/cmake-api/
 #
 ####
 
@@ -17,11 +17,6 @@ set(SOURCE_FILES
 
 # Uncomment and add any modules that this component depends on, else
 # they might not be available when cmake tries to build this component.
-#
-# Module names are derived from the path from the nearest project/library/framework
-# root when not specifically overridden by the developer. i.e. The module defined by
-# `Ref/SignalGen/CMakeLists.txt` will be named `Ref_SignalGen`.  `Ref/SignalGen`
-# is an acceptable alternative and will be internally converted to `Ref_SignalGen`.
 #
 # set(MOD_DEPS
 #   MyPackage_MyOtherModule

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -88,9 +88,9 @@ class Gcovr(ExecutableAction):
             None if include_type_ac else ".*SerializableAc.[ch]pp",
             None if include_type_ac else ".*ArrayAc.[ch]pp",
             None if include_type_ac else ".*EnumAc.[ch]pp",
-            None if include_test_ac else ".*/GTestBase.[ch]pp",
-            None if include_test_ac else ".*/TesterBase.[ch]pp",
-            None if include_test_ac else ".*/TesterHelpers.[ch]pp",
+            None if include_test_ac else ".*/.*GTestBase.[ch]pp",
+            None if include_test_ac else ".*/.*TesterBase.[ch]pp",
+            None if include_test_ac else ".*/.*TesterHelpers.[ch]pp",
         ]
         raw_source_exclusion_filter_bases = [
             None if include_test else ".*/test/ut/.*",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3325 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Found an incorrect behavior in `fprime-util check` – `--test-ac` would implicitly be enabled by default

This was tested and is now behaving correctly.

Also fixing some old URLs

Fixes https://github.com/nasa/fprime/issues/3325
