### PR TITLE
Fixes fprime-util purge error on broken directory

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -94,6 +94,7 @@ class Build:
             if not force:
                 raise InvalidBuildCacheException(msg)
 
+  
     def load(self, platform: str = None, build_dir: Path = None, skip_validation=False):
         """Load an existing build cache
 
@@ -110,31 +111,29 @@ class Build:
             InvalidBuildCacheException: the build cache does not exist as it must
         """
         self.__setup_default(platform, build_dir)
-        # We only load empty directories or directories that contain the .fprime-build-dir file
-        if not skip_validation and (
-            not self.build_dir.exists()
-            or (
-                len(os.listdir(self.build_dir)) > 0
-                and not (self.build_dir / ".fprime-build-dir").exists()
+        
+        if skip_validation:
+            return
+        if self.build_dir.exists() and len(os.listdir(self.build_dir)) == 0 or (self.build_dir / ".fprime-build-dir").exists():
+            return
+        
+        # Message for hard-supplied --build-cache message
+        if build_dir is not None:
+            gen_args = f" --build-cache {build_dir}"
+        else:
+            gen_args = " --ut" if self.build_type == BuildType.BUILD_TESTING else ""
+            gen_args += (
+                " " + platform
+                if platform is not None
+                and platform != "native"
+                and platform != "default"
+                else ""
             )
-        ):
-            # Message for hard-supplied --build-cache message
-            if build_dir is not None:
-                gen_args = f" --build-cache {build_dir}"
-            else:
-                gen_args = " --ut" if self.build_type == BuildType.BUILD_TESTING else ""
-                gen_args += (
-                    " " + platform
-                    if platform is not None
-                    and platform != "native"
-                    and platform != "default"
-                    else ""
-                )
-            msg = f"'{self.build_dir}' is not a valid build cache. Generate this build cache with 'fprime-util generate{gen_args} ...'"
-            raise InvalidBuildCacheException(
-                msg,
-                self.build_dir,
-            )
+        msg = f"'{self.build_dir}' is not a valid build cache. Generate this build cache with 'fprime-util generate{gen_args} ...'"
+        raise InvalidBuildCacheException(
+            msg,
+            self.build_dir,
+        )
 
     def get_settings(
         self,

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -112,7 +112,8 @@ class Build:
         self.__setup_default(platform, build_dir)
         if not skip_validation and (
             not self.build_dir.exists()
-            or not (self.build_dir / "CMakeCache.txt").exists()
+            or (len(os.listdir(self.build_dir)) > 0 and 
+            not (self.build_dir / ".fprime-build-dir").exists())
         ):
             # Message for hard-supplied --build-cache message
             if build_dir is not None:

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -113,11 +113,7 @@ class Build:
 
         if skip_validation:
             return
-        if (
-            self.build_dir.exists()
-            and len(os.listdir(self.build_dir)) == 0
-            or (self.build_dir / ".fprime-build-dir").exists()
-        ):
+        if self.build_dir.exists() or (self.build_dir / ".fprime-build-dir").exists():
             return
 
         # Message for hard-supplied --build-cache message

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -94,7 +94,6 @@ class Build:
             if not force:
                 raise InvalidBuildCacheException(msg)
 
-  
     def load(self, platform: str = None, build_dir: Path = None, skip_validation=False):
         """Load an existing build cache
 
@@ -111,12 +110,16 @@ class Build:
             InvalidBuildCacheException: the build cache does not exist as it must
         """
         self.__setup_default(platform, build_dir)
-        
+
         if skip_validation:
             return
-        if self.build_dir.exists() and len(os.listdir(self.build_dir)) == 0 or (self.build_dir / ".fprime-build-dir").exists():
+        if (
+            self.build_dir.exists()
+            and len(os.listdir(self.build_dir)) == 0
+            or (self.build_dir / ".fprime-build-dir").exists()
+        ):
             return
-        
+
         # Message for hard-supplied --build-cache message
         if build_dir is not None:
             gen_args = f" --build-cache {build_dir}"

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -113,7 +113,7 @@ class Build:
 
         if skip_validation:
             return
-        if self.build_dir.exists() or (self.build_dir / ".fprime-build-dir").exists():
+        if self.build_dir is not None and (self.build_dir / ".fprime-build-dir").exists():
             return
 
         # Message for hard-supplied --build-cache message

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -113,7 +113,10 @@ class Build:
 
         if skip_validation:
             return
-        if self.build_dir is not None and (self.build_dir / ".fprime-build-dir").exists():
+        if (
+            self.build_dir is not None
+            and (self.build_dir / ".fprime-build-dir").exists()
+        ):
             return
 
         # Message for hard-supplied --build-cache message

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -110,10 +110,13 @@ class Build:
             InvalidBuildCacheException: the build cache does not exist as it must
         """
         self.__setup_default(platform, build_dir)
+        # We only load empty directories or directories that contain the .fprime-build-dir file
         if not skip_validation and (
             not self.build_dir.exists()
-            or (len(os.listdir(self.build_dir)) > 0 and 
-            not (self.build_dir / ".fprime-build-dir").exists())
+            or (
+                len(os.listdir(self.build_dir)) > 0
+                and not (self.build_dir / ".fprime-build-dir").exists()
+            )
         ):
             # Message for hard-supplied --build-cache message
             if build_dir is not None:

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -282,7 +282,7 @@ class CMakeHandler:
             args.keys(),
         )
         # Creating a file to mark the directory as a F Prime directory
-        Path(build_dir / ".fprime-build-dir").touch()
+        (Path(build_dir) / ".fprime-build-dir").touch()
         self.cmake_validate_source_dir(source_dir)
         self._run_cmake(
             ["-S", source_dir] + list(fleshed_args),

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -280,6 +280,8 @@ class CMakeHandler:
             ),
             args.keys(),
         )
+        # Creating a file to mark the directory as a F Prime directory
+        open(build_dir / ".fprime-build-dir", "w")
         self.cmake_validate_source_dir(source_dir)
         self._run_cmake(
             ["-S", source_dir] + list(fleshed_args),

--- a/src/fprime/fbuild/cmake.py
+++ b/src/fprime/fbuild/cmake.py
@@ -14,6 +14,7 @@ import copy
 import functools
 import itertools
 import os
+from pathlib import Path
 import pty
 import re
 import selectors
@@ -281,7 +282,7 @@ class CMakeHandler:
             args.keys(),
         )
         # Creating a file to mark the directory as a F Prime directory
-        open(build_dir / ".fprime-build-dir", "w")
+        Path(build_dir / ".fprime-build-dir").touch()
         self.cmake_validate_source_dir(source_dir)
         self._run_cmake(
             ["-S", source_dir] + list(fleshed_args),

--- a/test/fprime/fbuild/test_build.py
+++ b/test/fprime/fbuild/test_build.py
@@ -46,7 +46,9 @@ def test_hash_finder():
     builder = fprime.fbuild.builder.Build(
         fprime.fbuild.builder.BuildType.BUILD_NORMAL, dep_dir
     )
-    builder.load(local, build_dir=dep_dir / "build-fprime-automatic-native")
+    builder.load(
+        local, build_dir=dep_dir / "build-fprime-automatic-native", skip_validation=True
+    )
 
     assert builder.find_hashed_file(0xDEADBEEF) == ["Abc: 0xdeadbeef\n"]
     assert builder.find_hashed_file(0xC0DEC0DE) == ["HJK: 0xc0dec0de\n"]

--- a/test/fprime/fbuild/test_cmake.py
+++ b/test/fprime/fbuild/test_cmake.py
@@ -1,8 +1,9 @@
-""" Test CMake interaction
+"""Test CMake interaction
 
 This file contains a set of tests for validating CMake interaction on the back-end of fprime-util. These tests poke at
 the CMakeHandler component.
 """
+
 import json
 import os
 import shutil
@@ -460,6 +461,7 @@ def test_refresh_cache_noop_with_environment(cmake_handler):
 
 @patch("os.makedirs")
 @patch("os.path.exists")
+@patch("pathlib.Path.touch")
 @patch("fprime.fbuild.cmake.CMakeHandler.cmake_validate_source_dir")
 @patch("fprime.fbuild.cmake.CMakeHandler._run_cmake")
 def generate_build(
@@ -468,6 +470,7 @@ def generate_build(
     cmake_handler,
     mock_run_cmake,
     mock_validate_source_dir,
+    mock_touch,
     mock_path_exists,
     mock_makedirs,
     **kwargs,
@@ -492,6 +495,9 @@ def generate_build(
 
     # Call the generate_build function
     cmake_handler.generate_build(source_dir, build_dir, **kwargs)
+
+    # Asset that the touch method was called once
+    mock_touch.assert_called_once()
 
     # Assert that cmake_validate_source_dir was called with the correct source_dir
     mock_validate_source_dir.assert_called_once_with(source_dir)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The bug occurs when the fprime-util generate command is interrupted (such as with Ctrl+C) before the directory can finish building. This results in the fprime-util purge command to error out since it is unable to verify if the directory it is trying to delete is an F Prime directory.

The proposed fix adds an empty file early on in the directory's build process, allowing the purge command to identify that the directory it is trying to delete is an F Prime directory. New logic has also been added to allow the purge command to delete directories that are empty.  

## Rationale

This change Fixes nasa/fprime#3033 
