### PR TITLE
Allow `fprime-util new` to create components within deployments

### DIFF
--- a/src/fprime/common/utils.py
+++ b/src/fprime/common/utils.py
@@ -1,4 +1,4 @@
-""" fprime.common.utils: defines common utility functions to be used across sub packages
+"""fprime.common.utils: defines common utility functions to be used across sub packages
 
 @author thomas-bc
 """
@@ -54,7 +54,7 @@ def check_path_is_within_fprime_module(path: Path, is_component: bool):
     statement = "register_fprime_"
     if is_component:
         statement += "module"
-        
+
     for line in lines:
         if line.startswith(statement):
             return True

--- a/src/fprime/common/utils.py
+++ b/src/fprime/common/utils.py
@@ -28,7 +28,7 @@ def replace_contents(filename, what, replacement, count=1):
         return new_file != changelog
 
 
-def check_path_is_within_fprime_module(path: Path, is_component: bool):
+def check_path_is_within_fprime_module(path: Path, is_component: bool = False):
     """Check if the current working directory is within an F prime component or deployment module
 
     This is done by checking if any line in the path/CMakeLists.txt file starts

--- a/src/fprime/common/utils.py
+++ b/src/fprime/common/utils.py
@@ -28,16 +28,20 @@ def replace_contents(filename, what, replacement, count=1):
         return new_file != changelog
 
 
-def check_path_is_within_fprime_module(path: Path):
-    """Check if the current working directory is within an F prime module
+def check_path_is_within_fprime_module(path: Path, is_component: bool):
+    """Check if the current working directory is within an F prime component or deployment module
 
     This is done by checking if any line in the path/CMakeLists.txt file starts
-    with register_fprime_*
+    with register_fprime_* to identify both component and deployment modules or
+    register_fprime_module to identify only component modules.
 
     This is useful to prevent users from running commands in the wrong location.
+    New components can be created within a deployment module but not within a
+    component module. New deployments cannot be created in deployment or component
+    modules.
 
     Returns:
-        bool: True if the path is within an F prime module, False otherwise
+        bool: True if the path is within a valid F prime module, False otherwise
     """
 
     if not Path(path / "CMakeLists.txt").exists():
@@ -48,6 +52,9 @@ def check_path_is_within_fprime_module(path: Path):
 
     # Looks for line "register_fprime_*" in CMakeLists.txt
     statement = "register_fprime_"
+    if is_component:
+        statement += "module"
+        
     for line in lines:
         if line.startswith(statement):
             return True

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -88,9 +88,9 @@ def find_nearest_cmake_file(component_dir: Path, cmake_root: Path, proj_root: Pa
 def new_component(build: Build, parsed_args: "argparse.Namespace"):
     """Uses cookiecutter for making new components"""
 
-    if check_path_is_within_fprime_module(Path.cwd()) and not parsed_args.force:
+    if check_path_is_within_fprime_module(path=Path.cwd(), is_component=True) and not parsed_args.force:
         print(
-            "[ERROR] Wrong location. Cannot create component within an existing component or deployment."
+            "[ERROR] Wrong location. Cannot create component within an existing component."
             " Use --force to override."
         )
         return 1
@@ -157,7 +157,7 @@ def new_component(build: Build, parsed_args: "argparse.Namespace"):
 def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
     """Creates a new deployment using cookiecutter"""
 
-    if check_path_is_within_fprime_module(Path.cwd()) and not parsed_args.force:
+    if check_path_is_within_fprime_module(path=Path.cwd(), is_component=False) and not parsed_args.force:
         print(
             "[ERROR] Wrong location. Cannot create deployment within an existing component or deployment"
         )

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -1,5 +1,4 @@
-""" Cookie cutter wrapper used to template out components
-"""
+"""Cookie cutter wrapper used to template out components"""
 
 import glob
 import os
@@ -88,7 +87,10 @@ def find_nearest_cmake_file(component_dir: Path, cmake_root: Path, proj_root: Pa
 def new_component(build: Build, parsed_args: "argparse.Namespace"):
     """Uses cookiecutter for making new components"""
 
-    if check_path_is_within_fprime_module(path=Path.cwd(), is_component=True) and not parsed_args.force:
+    if (
+        check_path_is_within_fprime_module(path=Path.cwd(), is_component=True)
+        and not parsed_args.force
+    ):
         print(
             "[ERROR] Wrong location. Cannot create component within an existing component."
             " Use --force to override."
@@ -157,7 +159,10 @@ def new_component(build: Build, parsed_args: "argparse.Namespace"):
 def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
     """Creates a new deployment using cookiecutter"""
 
-    if check_path_is_within_fprime_module(path=Path.cwd(), is_component=False) and not parsed_args.force:
+    if (
+        check_path_is_within_fprime_module(path=Path.cwd(), is_component=False)
+        and not parsed_args.force
+    ):
         print(
             "[ERROR] Wrong location. Cannot create deployment within an existing component or deployment"
         )

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -159,10 +159,7 @@ def new_component(build: Build, parsed_args: "argparse.Namespace"):
 def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
     """Creates a new deployment using cookiecutter"""
 
-    if (
-        check_path_is_within_fprime_module(Path.cwd())
-        and not parsed_args.force
-    ):
+    if check_path_is_within_fprime_module(Path.cwd()) and not parsed_args.force:
         print(
             "[ERROR] Wrong location. Cannot create deployment within an existing component or deployment"
         )

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -160,7 +160,7 @@ def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
     """Creates a new deployment using cookiecutter"""
 
     if (
-        check_path_is_within_fprime_module(path=Path.cwd(), is_component=False)
+        check_path_is_within_fprime_module(Path.cwd())
         and not parsed_args.force
     ):
         print(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime #3321 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This change allows the `fprime-util new --component` command to create new components within deployment directories. This change affects the 'prime-util new --deployment` command, but leaves it with the same functionality as before.

## Rationale

This change fixes nasa/fprime#3321

