### PR TITLE
Connect ComQueue run port

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,20 +26,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install System dependencies
         run: |
           python -m pip install --upgrade pip urllib3 setuptools_scm
           sudo apt-get install ninja-build
-      - name: clone fprime and gps-tutorial
+      - name: Clone fprime and install requirements.txt
         run: |
           git clone --recurse-submodules -b ${{ matrix.fprime-version }} https://github.com/nasa/fprime.git
-          git clone --recurse-submodules https://github.com/fprime-community/gps-tutorial.git
           pip install -r fprime/requirements.txt || true # Attempt to install fprime package when available
-      - name: Generate correct fprime version in gps-tutorial
-        working-directory: gps-tutorial
-        run: git submodule update --recursive
-      - name: Install Current fpp-tools
-        run: pip install .
+      - name: Install Current fprime-tools
+        run: pip install -U .
       # 0x72ad3277 is Fw/Types/Assert.cpp, a file that should be consistent across releases
       - name: Test generation and building on Ref
         working-directory: fprime/Ref
@@ -47,16 +43,8 @@ jobs:
           fprime-util generate
           fprime-util build
           fprime-util hash-to-file 0x72ad3277
-      - name: Test generation and building on gps-tutorial
-        working-directory: gps-tutorial/GpsApp
-        run: |
-          fprime-util generate
-          fprime-util build
-          fprime-util hash-to-file 0x72ad3277
       - name: Test generation and building on Ref with Ninja
         working-directory: fprime/Ref
-        # There is a bug in v3.0.0 that causes ninja builds to fail
-        if: matrix.fprime-version != 'v3.0.0'
         run: |
           fprime-util generate --ninja --build-cache ./build-ninja
           fprime-util build --build-cache ./build-ninja

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
@@ -101,6 +101,7 @@ module {{cookiecutter.deployment_name}} {
       rateGroup1.RateGroupMemberOut[0] -> tlmSend.Run
       rateGroup1.RateGroupMemberOut[1] -> fileDownlink.Run
       rateGroup1.RateGroupMemberOut[2] -> systemResources.run
+      rateGroup1.RateGroupMemberOut[3] -> comQueue.run
 
       # Rate group 2
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2.CycleIn

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -123,12 +123,16 @@ void configureTopology(const TopologyState& state) {
     // Note: Uncomment when using Svc:TlmPacketizer
     // tlmSend.setPacketList({{cookiecutter.deployment_name}}PacketsPkts, {{cookiecutter.deployment_name}}PacketsIgnore, 1);
 
+    // ComQueue configuration
     // Events (highest-priority)
-    configurationTable.entries[0] = {.depth = 100, .priority = 0};
+    configurationTable.entries[0].depth = 100;
+    configurationTable.entries[0].priority = 0;
     // Telemetry
-    configurationTable.entries[1] = {.depth = 500, .priority = 2};
+    configurationTable.entries[1].depth = 500;
+    configurationTable.entries[1].priority = 2;
     // File Downlink
-    configurationTable.entries[2] = {.depth = 100, .priority = 1};
+    configurationTable.entries[2].depth = 100;
+    configurationTable.entries[2].priority = 1;
     // Allocation identifier is 0 as the MallocAllocator discards it
     comQueue.configure(configurationTable, 0, mallocator);
 {%- if (cookiecutter.com_driver_type in ["TcpServer", "TcpClient"]) %}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The ComQueue run port has not been connected in the topology, so we don't get any telemetry from the ComQueue. Adding the connection by default in the cookiecutter

## Review Recommendation

Confirm this is intended behavior