### PR TITLE
Improve error message clarity for nasa/fprime#3099

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -337,7 +337,7 @@ class Build:
             possible_path = self.build_dir / possible / project_relative_path
             if possible_path.exists():
                 return possible_path
-        msg = f"{context} has no associated build cache path"
+        msg = f"The call to add_fprime_subdirectory could not be found for ComponentName\nPlease check the CMakeLists.txt files in the parent directories of {context}"
         raise MissingBuildCachePath(msg)
 
     def get_relative_path(self, path: Path) -> Path:

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -337,7 +337,8 @@ class Build:
             possible_path = self.build_dir / possible / project_relative_path
             if possible_path.exists():
                 return possible_path
-        msg = f"The call to add_fprime_subdirectory could not be found for ComponentName\nPlease check the CMakeLists.txt files in the parent directories of {context}"
+        component_name = os.path.basename(context)
+        msg = f"The call to add_fprime_subdirectory could not be found for {component_name}\nPlease check the CMakeLists.txt files in the parent directories of {context}"
         raise MissingBuildCachePath(msg)
 
     def get_relative_path(self, path: Path) -> Path:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime #3099 |  
|**_Has Unit Tests (y/n)_**|y  |
|**_Documentation Included (y/n)_**|  y|

---
## Change Description

Original issue: https://github.com/nasa/fprime/issues/3099

Changes:
+ Adds clarity to error message: what happened and how to solve it. 


## Rationale

Message raised when trying to **fprime-util impl** in a component which existence is not recognized in CMakeLists.txt

**First** thing I did was try to **reproduce the error message**:
1. First configure the project via bootstrap.
2. Create the component: fprime-util new --component
3. Last two question answered NO. (Dont add it to CMakeLists nor generate implementation files)
4. Build it: fprime-util build
5. Navigate to component folder and do fprime-util impl

**Second**, executed grep command.

Executed grep -rn "has no associated build cache path". Time passes. Nothing returns.
Uh? May be is a dynamic string. Let me try fragmenting the error message. No, that just lead me to a end-road.
Experimented hours. Created projects from start, and this time without using bootstrap.
Executed grep one more time in those projects from scratch... Gotcha. 
Inside builder.py implementation file, from fprime-tools superset

![image](https://github.com/user-attachments/assets/f5b1b3c6-1f24-49f7-96f7-0219e670beec)

**Third**, change the error message.
Straightforward. 

## Testing/Review Recommendations

Now, for the sake of showing how it seems the new error message (when no adding the component to the CMakeLists):
![image](https://github.com/user-attachments/assets/6d6ea8f2-ab39-4bf1-a69a-33a1b13005c7)
