### PR TITLE
Handle CMake files that miss a trailing newline

### DIFF
--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -317,6 +317,10 @@ def add_to_cmake(list_file: Path, comp_path: Path, project_root: Path = None):
     if not confirm(f"Add {comp_path} to {short_display_path} at end of file?"):
         return False
 
+    # Handle calse where the last line does not end with a newline
+    if lines and (not lines[-1].endswith("\n")):
+        lines[-1] += "\n"
+
     lines.append(addition)
     with open(list_file, "w") as f:
         f.write("".join(lines))

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -317,7 +317,7 @@ def add_to_cmake(list_file: Path, comp_path: Path, project_root: Path = None):
     if not confirm(f"Add {comp_path} to {short_display_path} at end of file?"):
         return False
 
-    # Handle calse where the last line does not end with a newline
+    # Handle case where the last line does not end with a newline
     if len(lines) > 0 and (not lines[-1].endswith("\n")):
         lines[-1] += "\n"
 

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -318,7 +318,7 @@ def add_to_cmake(list_file: Path, comp_path: Path, project_root: Path = None):
         return False
 
     # Handle calse where the last line does not end with a newline
-    if lines and (not lines[-1].endswith("\n")):
+    if len(lines) > 0 and (not lines[-1].endswith("\n")):
         lines[-1] += "\n"
 
     lines.append(addition)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3484 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/3484
