### PR TITLE
Detect new deployment creation in non-root dir and adjust includes (nasa/fprime#3505)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -71,6 +71,7 @@ rpaetz
 rst
 sanitizers
 SCLK
+Sibo
 someotherpath
 stackoverflow
 stderrs

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/cookiecutter.json
@@ -1,6 +1,7 @@
 {
     "deployment_name": "MyDeployment",
     "com_driver_type": ["TcpClient", "TcpServer", "UART"],
+    "__include_path_prefix": "",
     "__deployment_name_upper": "{{cookiecutter.deployment_name.upper()}}",
     "__prompts__": {
         "deployment_name": "Deployment name",

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Main.cpp
@@ -4,7 +4,7 @@
 //
 // ======================================================================
 // Used to access topology functions
-#include <{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp>
+#include <{{cookiecutter.__include_path_prefix}}{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp>
 // OSAL initialization
 #include <Os/Os.hpp>
 // Used for signal handling shutdown

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -4,9 +4,9 @@
 //
 // ======================================================================
 // Provides access to autocoded functions
-#include <{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyAc.hpp>
+#include <{{cookiecutter.__include_path_prefix}}{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyAc.hpp>
 // Note: Uncomment when using Svc:TlmPacketizer
-//#include <{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}PacketsAc.hpp>
+//#include <{{cookiecutter.__include_path_prefix}}{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}PacketsAc.hpp>
 
 // Necessary project-specified types
 #include <Fw/Types/MallocAllocator.hpp>

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
@@ -7,7 +7,7 @@
 #define {{cookiecutter.__deployment_name_upper}}_{{cookiecutter.__deployment_name_upper}}TOPOLOGY_HPP
 // Included for access to {{cookiecutter.deployment_name}}::TopologyState and {{cookiecutter.deployment_name}}::ConfigObjects::pingEntries. These definitions are required by the
 // autocoder, but are also used in this hand-coded topology.
-#include <{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp>
+#include <{{cookiecutter.__include_path_prefix}}{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp>
 
 // Remove unnecessary {{cookiecutter.deployment_name}}:: qualifications
 using namespace {{cookiecutter.deployment_name}};

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}TopologyDefs.hpp
@@ -8,7 +8,7 @@
 
 #include "Drv/BlockDriver/BlockDriver.hpp"
 #include "Fw/Types/MallocAllocator.hpp"
-#include "{{cookiecutter.deployment_name}}/Top/FppConstantsAc.hpp"
+#include "{{cookiecutter.__include_path_prefix}}{{cookiecutter.deployment_name}}/Top/FppConstantsAc.hpp"
 #include "Svc/FramingProtocol/FprimeProtocol.hpp"
 #include "Svc/Health/Health.hpp"
 

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -186,8 +186,10 @@ def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
 
     if rel_path:
         extra_context["__include_path_prefix"] = f"{rel_path}/"
-        print(f"[INFO] Creating a deployment in a subdirectory. Include paths will be prefixed with '{rel_path}/'")
-        
+        print(
+            f"[INFO] Creating a deployment in a subdirectory. Include paths will be prefixed with '{rel_path}/'"
+        )
+
     try:
         gen_path = Path(
             cookiecutter(

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -178,9 +178,35 @@ def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
             + "/../cookiecutter_templates/cookiecutter-fprime-deployment"
         )
         print("[INFO] Cookiecutter: using builtin template for new deployment")
+
+    # Determine the include path prefix based on the current directory
+    proj_root = Path(build.get_settings("project_root", None)).resolve()
+    cwd = Path.cwd()
+    extra_context = {}
+
+    # If we're in a subdirectory of the project root, set the include_path_prefix
+    if proj_root != cwd and proj_root in cwd.parents:
+        # Get the relative path from project root to current directory
+        rel_path = cwd.relative_to(proj_root)
+
+        # Ask for confirmation before setting the include path prefix
+        if confirm(
+            f"You are creating a deployment in a subdirectory '{rel_path}'. "
+            f"Would you like to adjust include paths to account for this?"
+        ):
+            # Use the relative path as the include path prefix
+            extra_context["__include_path_prefix"] = f"{rel_path}/"
+            print(f"[INFO] Include paths will be prefixed with '{rel_path}/'")
+        else:
+            print("[INFO] Include paths will not be adjusted")
+
     try:
         gen_path = Path(
-            cookiecutter(source, overwrite_if_exists=parsed_args.overwrite)
+            cookiecutter(
+                source,
+                extra_context=extra_context,
+                overwrite_if_exists=parsed_args.overwrite,
+            )
         ).resolve()
         # Attempt to register to CMakeLists.txt or project.cmake
         register_with_cmake(

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -15,6 +15,7 @@ from fprime.common.utils import confirm, check_path_is_within_fprime_module
 from fprime.fbuild.builder import Build
 from fprime.fbuild.cmake import CMakeExecutionException
 from fprime.fpp.impl import fpp_generate_implementation
+from fprime.util.file_util import get_directory_path_relative_to_root
 
 if TYPE_CHECKING:
     import argparse
@@ -180,26 +181,13 @@ def new_deployment(build: Build, parsed_args: "argparse.Namespace"):
         print("[INFO] Cookiecutter: using builtin template for new deployment")
 
     # Determine the include path prefix based on the current directory
-    proj_root = Path(build.get_settings("project_root", None)).resolve()
-    cwd = Path.cwd()
     extra_context = {}
+    rel_path = get_directory_path_relative_to_root(build)
 
-    # If we're in a subdirectory of the project root, set the include_path_prefix
-    if proj_root != cwd and proj_root in cwd.parents:
-        # Get the relative path from project root to current directory
-        rel_path = cwd.relative_to(proj_root)
-
-        # Ask for confirmation before setting the include path prefix
-        if confirm(
-            f"You are creating a deployment in a subdirectory '{rel_path}'. "
-            f"Would you like to adjust include paths to account for this?"
-        ):
-            # Use the relative path as the include path prefix
-            extra_context["__include_path_prefix"] = f"{rel_path}/"
-            print(f"[INFO] Include paths will be prefixed with '{rel_path}/'")
-        else:
-            print("[INFO] Include paths will not be adjusted")
-
+    if rel_path:
+        extra_context["__include_path_prefix"] = f"{rel_path}/"
+        print(f"[INFO] Creating a deployment in a subdirectory. Include paths will be prefixed with '{rel_path}/'")
+        
     try:
         gen_path = Path(
             cookiecutter(

--- a/src/fprime/util/file_util.py
+++ b/src/fprime/util/file_util.py
@@ -1,0 +1,36 @@
+"""fprime.util.file_util: Utility functions for general file operations
+
+@author SiboVG
+"""
+
+from pathlib import Path
+
+from fprime.fbuild.builder import Build
+
+
+def get_directory_path_relative_to_root(build: Build) -> str:
+    """
+    Get the directory path of the current directory (from which F` tools is executed)
+    relative to the root of the F` project.
+
+    If the current directory is the project root, it returns an empty string.
+    If the current directory is a subdirectory of the project root, it returns the relative path.
+    If the current directory is not within the project root, it returns None.
+
+    Args:
+        build (Build): The build object containing project settings.
+    Returns:
+        str: The relative path from the project root to the current directory,
+            an empty string if the current directory is the project root,
+            or None if not within the project root.
+    """
+    proj_root = Path(build.get_settings("project_root", None)).resolve()
+    cwd = Path.cwd()
+
+    if proj_root == cwd:
+        return ""
+
+    if proj_root not in cwd.parents:
+        return None
+
+    return str(cwd.relative_to(proj_root))

--- a/src/fprime/util/file_util.py
+++ b/src/fprime/util/file_util.py
@@ -24,7 +24,12 @@ def get_directory_path_relative_to_root(build: Build) -> str:
             an empty string if the current directory is the project root,
             or None if not within the project root.
     """
-    proj_root = Path(build.get_settings("project_root", None)).resolve()
+    proj_root = build.get_settings("project_root", None)
+    if proj_root is None:
+        print("[WARNING] No project root found. Cannot determine relative path.")
+        return None
+
+    proj_root = Path(proj_root).resolve()
     cwd = Path.cwd()
 
     if proj_root == cwd:

--- a/test/fprime/fbuild/test_new_deployment.py
+++ b/test/fprime/fbuild/test_new_deployment.py
@@ -1,5 +1,6 @@
 """
-Test the new_deployment function in fprime.util.cookiecutter_wrapper
+(test) fprime.util.cookiecutter_wrapper - new_deployment():
+Test adding a new deployment to a project using cookiecutter.
 
 This test verifies the behavior of creating deployments in non-root directories,
 specifically testing the automatic detection and adjustment of include paths.
@@ -52,9 +53,8 @@ class TestNewDeployment(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     @patch("fprime.util.cookiecutter_wrapper.cookiecutter")
-    @patch("fprime.util.cookiecutter_wrapper.confirm")
     @patch("fprime.util.cookiecutter_wrapper.register_with_cmake")
-    def test_new_deployment_in_root_dir(self, mock_register, mock_confirm, mock_cookiecutter):
+    def test_new_deployment_in_root_dir(self, mock_register, mock_cookiecutter):
         """Test creating a deployment in the project root directory"""
         # Change to the project root directory
         os.chdir(self.project_root)
@@ -78,9 +78,6 @@ class TestNewDeployment(unittest.TestCase):
         # Verify the result
         self.assertEqual(result, 0)
         
-        # Verify that confirm was not called (since we're in the root directory)
-        mock_confirm.assert_not_called()
-        
         # Verify that cookiecutter was called with the correct arguments
         mock_cookiecutter.assert_called_once()
         args, kwargs = mock_cookiecutter.call_args
@@ -88,10 +85,9 @@ class TestNewDeployment(unittest.TestCase):
         self.assertEqual(kwargs["extra_context"], {})  # No include path prefix
 
     @patch("fprime.util.cookiecutter_wrapper.cookiecutter")
-    @patch("fprime.util.cookiecutter_wrapper.confirm")
     @patch("fprime.util.cookiecutter_wrapper.register_with_cmake")
-    def test_new_deployment_in_subdir_confirmed(self, mock_register, mock_confirm, mock_cookiecutter):
-        """Test creating a deployment in a subdirectory with confirmation"""
+    def test_new_deployment_in_subdir(self, mock_register, mock_cookiecutter):
+        """Test creating a deployment in a subdirectory"""
         # Change to the Deployments directory
         os.chdir(self.deployments_dir)
         
@@ -105,9 +101,6 @@ class TestNewDeployment(unittest.TestCase):
         mock_args.force = False
         mock_args.overwrite = False
         
-        # Mock the confirm function to return True (user confirms)
-        mock_confirm.return_value = True
-        
         # Mock the cookiecutter function to return a path
         mock_cookiecutter.return_value = str(self.deployments_dir / "MyDeployment")
         
@@ -116,11 +109,6 @@ class TestNewDeployment(unittest.TestCase):
         
         # Verify the result
         self.assertEqual(result, 0)
-        
-        # Verify that confirm was called with the correct message
-        mock_confirm.assert_called_once()
-        args, kwargs = mock_confirm.call_args
-        self.assertIn("You are creating a deployment in a subdirectory", args[0])
         
         # Verify that cookiecutter was called with the correct arguments
         mock_cookiecutter.assert_called_once()
@@ -128,47 +116,6 @@ class TestNewDeployment(unittest.TestCase):
         self.assertIn("extra_context", kwargs)
         self.assertIn("__include_path_prefix", kwargs["extra_context"])
         self.assertEqual(kwargs["extra_context"]["__include_path_prefix"], "Deployments/")
-
-    @patch("fprime.util.cookiecutter_wrapper.cookiecutter")
-    @patch("fprime.util.cookiecutter_wrapper.confirm")
-    @patch("fprime.util.cookiecutter_wrapper.register_with_cmake")
-    def test_new_deployment_in_subdir_declined(self, mock_register, mock_confirm, mock_cookiecutter):
-        """Test creating a deployment in a subdirectory with confirmation declined"""
-        # Change to the Deployments directory
-        os.chdir(self.deployments_dir)
-        
-        # Mock the build object
-        mock_build = MagicMock(spec=Build)
-        mock_build.get_settings.return_value = self.project_root
-        mock_build.cmake_root = self.project_root
-        
-        # Mock the parsed arguments
-        mock_args = MagicMock()
-        mock_args.force = False
-        mock_args.overwrite = False
-        
-        # Mock the confirm function to return False (user declines)
-        mock_confirm.return_value = False
-        
-        # Mock the cookiecutter function to return a path
-        mock_cookiecutter.return_value = str(self.deployments_dir / "MyDeployment")
-        
-        # Call the function
-        result = new_deployment(mock_build, mock_args)
-        
-        # Verify the result
-        self.assertEqual(result, 0)
-        
-        # Verify that confirm was called with the correct message
-        mock_confirm.assert_called_once()
-        args, kwargs = mock_confirm.call_args
-        self.assertIn("You are creating a deployment in a subdirectory", args[0])
-        
-        # Verify that cookiecutter was called with the correct arguments
-        mock_cookiecutter.assert_called_once()
-        args, kwargs = mock_cookiecutter.call_args
-        self.assertIn("extra_context", kwargs)
-        self.assertEqual(kwargs["extra_context"], {})  # No include path prefix
 
 
 if __name__ == "__main__":

--- a/test/fprime/fbuild/test_new_deployment.py
+++ b/test/fprime/fbuild/test_new_deployment.py
@@ -1,0 +1,175 @@
+"""
+Test the new_deployment function in fprime.util.cookiecutter_wrapper
+
+This test verifies the behavior of creating deployments in non-root directories,
+specifically testing the automatic detection and adjustment of include paths.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from fprime.fbuild.builder import Build
+from fprime.util.cookiecutter_wrapper import new_deployment
+
+
+class TestNewDeployment(unittest.TestCase):
+    """Test the new_deployment function"""
+
+    def setUp(self):
+        """Set up a temporary directory structure for testing"""
+        # Create a temporary directory to simulate a project
+        self.temp_dir = tempfile.mkdtemp()
+        self.project_root = Path(self.temp_dir) / "project_root"
+        self.project_root.mkdir()
+        
+        # Create a subdirectory to simulate a Deployments directory
+        self.deployments_dir = self.project_root / "Deployments"
+        self.deployments_dir.mkdir()
+        
+        # Create a CMakeLists.txt file in the project root
+        with open(self.project_root / "CMakeLists.txt", "w") as f:
+            f.write("# Project CMakeLists.txt\n")
+        
+        # Create a settings.ini file in the project root
+        with open(self.project_root / "settings.ini", "w") as f:
+            f.write("[fprime]\n")
+            f.write("project_root = .\n")
+            f.write(f"framework_path = {self.project_root}\n")
+        
+        # Save the original working directory
+        self.original_cwd = os.getcwd()
+
+    def tearDown(self):
+        """Clean up temporary directory"""
+        # Change back to the original working directory
+        os.chdir(self.original_cwd)
+        
+        # Remove the temporary directory
+        shutil.rmtree(self.temp_dir)
+
+    @patch("fprime.util.cookiecutter_wrapper.cookiecutter")
+    @patch("fprime.util.cookiecutter_wrapper.confirm")
+    @patch("fprime.util.cookiecutter_wrapper.register_with_cmake")
+    def test_new_deployment_in_root_dir(self, mock_register, mock_confirm, mock_cookiecutter):
+        """Test creating a deployment in the project root directory"""
+        # Change to the project root directory
+        os.chdir(self.project_root)
+        
+        # Mock the build object
+        mock_build = MagicMock(spec=Build)
+        mock_build.get_settings.return_value = self.project_root
+        mock_build.cmake_root = self.project_root
+        
+        # Mock the parsed arguments
+        mock_args = MagicMock()
+        mock_args.force = False
+        mock_args.overwrite = False
+        
+        # Mock the cookiecutter function to return a path
+        mock_cookiecutter.return_value = str(self.project_root / "MyDeployment")
+        
+        # Call the function
+        result = new_deployment(mock_build, mock_args)
+        
+        # Verify the result
+        self.assertEqual(result, 0)
+        
+        # Verify that confirm was not called (since we're in the root directory)
+        mock_confirm.assert_not_called()
+        
+        # Verify that cookiecutter was called with the correct arguments
+        mock_cookiecutter.assert_called_once()
+        args, kwargs = mock_cookiecutter.call_args
+        self.assertIn("extra_context", kwargs)
+        self.assertEqual(kwargs["extra_context"], {})  # No include path prefix
+
+    @patch("fprime.util.cookiecutter_wrapper.cookiecutter")
+    @patch("fprime.util.cookiecutter_wrapper.confirm")
+    @patch("fprime.util.cookiecutter_wrapper.register_with_cmake")
+    def test_new_deployment_in_subdir_confirmed(self, mock_register, mock_confirm, mock_cookiecutter):
+        """Test creating a deployment in a subdirectory with confirmation"""
+        # Change to the Deployments directory
+        os.chdir(self.deployments_dir)
+        
+        # Mock the build object
+        mock_build = MagicMock(spec=Build)
+        mock_build.get_settings.return_value = self.project_root
+        mock_build.cmake_root = self.project_root
+        
+        # Mock the parsed arguments
+        mock_args = MagicMock()
+        mock_args.force = False
+        mock_args.overwrite = False
+        
+        # Mock the confirm function to return True (user confirms)
+        mock_confirm.return_value = True
+        
+        # Mock the cookiecutter function to return a path
+        mock_cookiecutter.return_value = str(self.deployments_dir / "MyDeployment")
+        
+        # Call the function
+        result = new_deployment(mock_build, mock_args)
+        
+        # Verify the result
+        self.assertEqual(result, 0)
+        
+        # Verify that confirm was called with the correct message
+        mock_confirm.assert_called_once()
+        args, kwargs = mock_confirm.call_args
+        self.assertIn("You are creating a deployment in a subdirectory", args[0])
+        
+        # Verify that cookiecutter was called with the correct arguments
+        mock_cookiecutter.assert_called_once()
+        args, kwargs = mock_cookiecutter.call_args
+        self.assertIn("extra_context", kwargs)
+        self.assertIn("__include_path_prefix", kwargs["extra_context"])
+        self.assertEqual(kwargs["extra_context"]["__include_path_prefix"], "Deployments/")
+
+    @patch("fprime.util.cookiecutter_wrapper.cookiecutter")
+    @patch("fprime.util.cookiecutter_wrapper.confirm")
+    @patch("fprime.util.cookiecutter_wrapper.register_with_cmake")
+    def test_new_deployment_in_subdir_declined(self, mock_register, mock_confirm, mock_cookiecutter):
+        """Test creating a deployment in a subdirectory with confirmation declined"""
+        # Change to the Deployments directory
+        os.chdir(self.deployments_dir)
+        
+        # Mock the build object
+        mock_build = MagicMock(spec=Build)
+        mock_build.get_settings.return_value = self.project_root
+        mock_build.cmake_root = self.project_root
+        
+        # Mock the parsed arguments
+        mock_args = MagicMock()
+        mock_args.force = False
+        mock_args.overwrite = False
+        
+        # Mock the confirm function to return False (user declines)
+        mock_confirm.return_value = False
+        
+        # Mock the cookiecutter function to return a path
+        mock_cookiecutter.return_value = str(self.deployments_dir / "MyDeployment")
+        
+        # Call the function
+        result = new_deployment(mock_build, mock_args)
+        
+        # Verify the result
+        self.assertEqual(result, 0)
+        
+        # Verify that confirm was called with the correct message
+        mock_confirm.assert_called_once()
+        args, kwargs = mock_confirm.call_args
+        self.assertIn("You are creating a deployment in a subdirectory", args[0])
+        
+        # Verify that cookiecutter was called with the correct arguments
+        mock_cookiecutter.assert_called_once()
+        args, kwargs = mock_cookiecutter.call_args
+        self.assertIn("extra_context", kwargs)
+        self.assertEqual(kwargs["extra_context"], {})  # No include path prefix
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/fprime/fbuild/test_new_deployment.py
+++ b/test/fprime/fbuild/test_new_deployment.py
@@ -26,21 +26,21 @@ class TestNewDeployment(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.project_root = Path(self.temp_dir) / "project_root"
         self.project_root.mkdir()
-        
+
         # Create a subdirectory to simulate a Deployments directory
         self.deployments_dir = self.project_root / "Deployments"
         self.deployments_dir.mkdir()
-        
+
         # Create a CMakeLists.txt file in the project root
         with open(self.project_root / "CMakeLists.txt", "w") as f:
             f.write("# Project CMakeLists.txt\n")
-        
+
         # Create a settings.ini file in the project root
         with open(self.project_root / "settings.ini", "w") as f:
             f.write("[fprime]\n")
             f.write("project_root = .\n")
             f.write(f"framework_path = {self.project_root}\n")
-        
+
         # Save the original working directory
         self.original_cwd = os.getcwd()
 
@@ -48,7 +48,7 @@ class TestNewDeployment(unittest.TestCase):
         """Clean up temporary directory"""
         # Change back to the original working directory
         os.chdir(self.original_cwd)
-        
+
         # Remove the temporary directory
         shutil.rmtree(self.temp_dir)
 
@@ -58,26 +58,26 @@ class TestNewDeployment(unittest.TestCase):
         """Test creating a deployment in the project root directory"""
         # Change to the project root directory
         os.chdir(self.project_root)
-        
+
         # Mock the build object
         mock_build = MagicMock(spec=Build)
         mock_build.get_settings.return_value = self.project_root
         mock_build.cmake_root = self.project_root
-        
+
         # Mock the parsed arguments
         mock_args = MagicMock()
         mock_args.force = False
         mock_args.overwrite = False
-        
+
         # Mock the cookiecutter function to return a path
         mock_cookiecutter.return_value = str(self.project_root / "MyDeployment")
-        
+
         # Call the function
         result = new_deployment(mock_build, mock_args)
-        
+
         # Verify the result
         self.assertEqual(result, 0)
-        
+
         # Verify that cookiecutter was called with the correct arguments
         mock_cookiecutter.assert_called_once()
         args, kwargs = mock_cookiecutter.call_args
@@ -90,32 +90,34 @@ class TestNewDeployment(unittest.TestCase):
         """Test creating a deployment in a subdirectory"""
         # Change to the Deployments directory
         os.chdir(self.deployments_dir)
-        
+
         # Mock the build object
         mock_build = MagicMock(spec=Build)
         mock_build.get_settings.return_value = self.project_root
         mock_build.cmake_root = self.project_root
-        
+
         # Mock the parsed arguments
         mock_args = MagicMock()
         mock_args.force = False
         mock_args.overwrite = False
-        
+
         # Mock the cookiecutter function to return a path
         mock_cookiecutter.return_value = str(self.deployments_dir / "MyDeployment")
-        
+
         # Call the function
         result = new_deployment(mock_build, mock_args)
-        
+
         # Verify the result
         self.assertEqual(result, 0)
-        
+
         # Verify that cookiecutter was called with the correct arguments
         mock_cookiecutter.assert_called_once()
         args, kwargs = mock_cookiecutter.call_args
         self.assertIn("extra_context", kwargs)
         self.assertIn("__include_path_prefix", kwargs["extra_context"])
-        self.assertEqual(kwargs["extra_context"]["__include_path_prefix"], "Deployments/")
+        self.assertEqual(
+            kwargs["extra_context"]["__include_path_prefix"], "Deployments/"
+        )
 
 
 if __name__ == "__main__":

--- a/test/fprime/util/test_file_util.py
+++ b/test/fprime/util/test_file_util.py
@@ -7,7 +7,6 @@ Tests the file utility functions for the fprime project.
 """
 
 import os
-import pathlib
 from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch

--- a/test/fprime/util/test_file_util.py
+++ b/test/fprime/util/test_file_util.py
@@ -1,0 +1,117 @@
+"""
+(test) fprime.util.file_util:
+
+Tests the file utility functions for the fprime project.
+
+@author SiboVG
+"""
+
+import os
+import pathlib
+from pathlib import Path
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fprime.fbuild.builder import Build
+from fprime.util.file_util import get_directory_path_relative_to_root
+
+
+@pytest.fixture
+def mock_build():
+    """Create a mock Build object for testing"""
+    mock = MagicMock(spec=Build)
+    return mock
+
+
+def test_current_dir_is_root(mock_build):
+    """Test when current directory is the project root"""
+    # Setup
+    mock_build.get_settings.return_value = str(Path.cwd())
+    
+    # Execute
+    result = get_directory_path_relative_to_root(mock_build)
+    
+    # Verify
+    assert result == ""
+    mock_build.get_settings.assert_called_once_with("project_root", None)
+
+
+@patch('fprime.util.file_util.Path.cwd')
+def test_current_dir_is_subdirectory(mock_cwd, mock_build):
+    """Test when current directory is a subdirectory of the project root"""
+    # Setup
+    root_path = Path('/path/to/project')
+    current_path = root_path / 'subdir1' / 'subdir2'
+    
+    mock_build.get_settings.return_value = str(root_path)
+    mock_cwd.return_value = current_path
+    
+    # Execute
+    result = get_directory_path_relative_to_root(mock_build)
+    
+    # Verify
+    assert result.replace(os.sep, '/') == "subdir1/subdir2"
+
+
+@patch('fprime.util.file_util.Path.cwd')
+def test_current_dir_outside_project(mock_cwd, mock_build):
+    """Test when current directory is outside the project root"""
+    # Setup
+    root_path = Path('/path/to/project')
+    current_path = Path('/different/path')
+    
+    mock_build.get_settings.return_value = str(root_path)
+    mock_cwd.return_value = current_path
+    
+    # Execute
+    result = get_directory_path_relative_to_root(mock_build)
+    
+    # Verify
+    assert result is None
+
+
+@patch('fprime.util.file_util.Path.cwd')
+def test_with_nested_directories(mock_cwd, mock_build):
+    """Test with deeply nested directories"""
+    # Setup
+    root_path = Path('/path/to/project')
+    current_path = root_path / 'a' / 'b' / 'c' / 'd'
+    
+    mock_build.get_settings.return_value = str(root_path)
+    mock_cwd.return_value = current_path
+    
+    # Execute
+    result = get_directory_path_relative_to_root(mock_build)
+    
+    # Verify
+    assert result.replace(os.sep, '/') == "a/b/c/d"
+
+
+def test_with_nonexistent_project_root(mock_build):
+    """Test behavior when project_root setting doesn't exist"""
+    # Setup
+    mock_build.get_settings.return_value = None
+    
+    # This should return None
+    result = get_directory_path_relative_to_root(mock_build)
+    assert result is None
+
+
+@patch('fprime.util.file_util.Path.cwd')
+def test_with_relative_path_in_settings(mock_cwd, mock_build):
+    """Test with a relative path in the settings"""
+    # Setup
+    root_path = Path('project')  # Relative path
+    abs_root_path = Path('/path/to/project')  # What it resolves to
+    current_path = abs_root_path / 'subdir'
+    
+    # Mock resolve to return the absolute path
+    with patch.object(Path, 'resolve', return_value=abs_root_path):
+        mock_build.get_settings.return_value = str(root_path)
+        mock_cwd.return_value = current_path
+        
+        # Execute
+        result = get_directory_path_relative_to_root(mock_build)
+        
+        # Verify
+        assert result == "subdir"

--- a/test/fprime/util/test_file_util.py
+++ b/test/fprime/util/test_file_util.py
@@ -27,91 +27,91 @@ def test_current_dir_is_root(mock_build):
     """Test when current directory is the project root"""
     # Setup
     mock_build.get_settings.return_value = str(Path.cwd())
-    
+
     # Execute
     result = get_directory_path_relative_to_root(mock_build)
-    
+
     # Verify
     assert result == ""
     mock_build.get_settings.assert_called_once_with("project_root", None)
 
 
-@patch('fprime.util.file_util.Path.cwd')
+@patch("fprime.util.file_util.Path.cwd")
 def test_current_dir_is_subdirectory(mock_cwd, mock_build):
     """Test when current directory is a subdirectory of the project root"""
     # Setup
-    root_path = Path('/path/to/project')
-    current_path = root_path / 'subdir1' / 'subdir2'
-    
+    root_path = Path("/path/to/project")
+    current_path = root_path / "subdir1" / "subdir2"
+
     mock_build.get_settings.return_value = str(root_path)
     mock_cwd.return_value = current_path
-    
+
     # Execute
     result = get_directory_path_relative_to_root(mock_build)
-    
+
     # Verify
-    assert result.replace(os.sep, '/') == "subdir1/subdir2"
+    assert result.replace(os.sep, "/") == "subdir1/subdir2"
 
 
-@patch('fprime.util.file_util.Path.cwd')
+@patch("fprime.util.file_util.Path.cwd")
 def test_current_dir_outside_project(mock_cwd, mock_build):
     """Test when current directory is outside the project root"""
     # Setup
-    root_path = Path('/path/to/project')
-    current_path = Path('/different/path')
-    
+    root_path = Path("/path/to/project")
+    current_path = Path("/different/path")
+
     mock_build.get_settings.return_value = str(root_path)
     mock_cwd.return_value = current_path
-    
+
     # Execute
     result = get_directory_path_relative_to_root(mock_build)
-    
+
     # Verify
     assert result is None
 
 
-@patch('fprime.util.file_util.Path.cwd')
+@patch("fprime.util.file_util.Path.cwd")
 def test_with_nested_directories(mock_cwd, mock_build):
     """Test with deeply nested directories"""
     # Setup
-    root_path = Path('/path/to/project')
-    current_path = root_path / 'a' / 'b' / 'c' / 'd'
-    
+    root_path = Path("/path/to/project")
+    current_path = root_path / "a" / "b" / "c" / "d"
+
     mock_build.get_settings.return_value = str(root_path)
     mock_cwd.return_value = current_path
-    
+
     # Execute
     result = get_directory_path_relative_to_root(mock_build)
-    
+
     # Verify
-    assert result.replace(os.sep, '/') == "a/b/c/d"
+    assert result.replace(os.sep, "/") == "a/b/c/d"
 
 
 def test_with_nonexistent_project_root(mock_build):
     """Test behavior when project_root setting doesn't exist"""
     # Setup
     mock_build.get_settings.return_value = None
-    
+
     # This should return None
     result = get_directory_path_relative_to_root(mock_build)
     assert result is None
 
 
-@patch('fprime.util.file_util.Path.cwd')
+@patch("fprime.util.file_util.Path.cwd")
 def test_with_relative_path_in_settings(mock_cwd, mock_build):
     """Test with a relative path in the settings"""
     # Setup
-    root_path = Path('project')  # Relative path
-    abs_root_path = Path('/path/to/project')  # What it resolves to
-    current_path = abs_root_path / 'subdir'
-    
+    root_path = Path("project")  # Relative path
+    abs_root_path = Path("/path/to/project")  # What it resolves to
+    current_path = abs_root_path / "subdir"
+
     # Mock resolve to return the absolute path
-    with patch.object(Path, 'resolve', return_value=abs_root_path):
+    with patch.object(Path, "resolve", return_value=abs_root_path):
         mock_build.get_settings.return_value = str(root_path)
         mock_cwd.return_value = current_path
-        
+
         # Execute
         result = get_directory_path_relative_to_root(mock_build)
-        
+
         # Verify
         assert result == "subdir"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#3505 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR fixes nasa/fprime#3505:
- When running `fprime-util new --deployment` in a directory that is not the root directory of the F` project, a confirm message will show asking whether you want to adjust the include paths in the created files:

```bash
$ fprime-util new --deployment
[INFO] Cookiecutter: using builtin template for new deployment
You are creating a deployment in a subdirectory 'Deployments'. Would you like to adjust include paths to account for this? (yes/no) [yes]: 
[INFO] Include paths will be prefixed with 'Deployments/'
  [1/2] Deployment name (MyDeployment): 
  [2/2] Select communication driver type
    1 - TcpClient
    2 - TcpServer
    3 - UART
    Choose from [1/2/3] (1): 
[INFO] Found CMake file at '<proj_root>/Deployments/CMakeLists.txt'
Add MyDeployment to <proj_root>/Deployments/CMakeLists.txt at end of file? (yes/no) [yes]: 
[INFO] New deployment successfully created: <proj_root>/Deployments/MyDeployment
```

## Rationale

This PR allows users to easily structure deployments in subdirectories without having to manually adjust the include paths in the generated files.

## Testing/Review Recommendations

Follow the reproductions steps from #3505 and verify that this PR resolves the issue. Also please take a look at the new unit test `test_new_deployment.py` works as expected.

## Future Work

Maybe also auto-generate a `CMakeLists.txt` file in the subdirectory if it does not exist yet?
