### PR TITLE
Add .items() to SerializableType and __iter__ to ArrayType

### DIFF
--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -1,8 +1,9 @@
-""" Generic representation of autocoded array types
+"""Generic representation of autocoded array types
 
 Created on May 29, 2020
 @author: jishii
 """
+
 from fprime.util.string_util import format_string_template
 
 from . import serializable_type
@@ -134,5 +135,5 @@ class ArrayType(DictionaryType):
         return cls.MEMBER_TYPE.getMaxSize() * cls.LENGTH
 
     def __iter__(self):
-        """ Allow the array object to be iterated """
+        """Allow the array object to be iterated"""
         return iter(self._val)

--- a/src/fprime/common/models/serialize/array_type.py
+++ b/src/fprime/common/models/serialize/array_type.py
@@ -3,7 +3,6 @@
 Created on May 29, 2020
 @author: jishii
 """
-
 from fprime.util.string_util import format_string_template
 
 from . import serializable_type
@@ -133,3 +132,7 @@ class ArrayType(DictionaryType):
     def getMaxSize(cls):
         """Return the maximum size in bytes of the array"""
         return cls.MEMBER_TYPE.getMaxSize() * cls.LENGTH
+
+    def __iter__(self):
+        """ Allow the array object to be iterated """
+        return iter(self._val)

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -176,9 +176,16 @@ class SerializableType(DictionaryType):
         return members
 
     def items(self):
-        """ Allow dictionary like iteration """
+        """Allow dictionary like iteration"""
+
         def items_generator():
-            """ Generator of items """
-            for member_name, member_value, member_format, member_desc in self.MEMBER_LIST:
+            """Generator of items"""
+            for (
+                member_name,
+                member_value,
+                member_format,
+                member_desc,
+            ) in self.MEMBER_LIST:
                 yield member_name, self._val.get(member_name)
+
         return items_generator()

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -180,12 +180,7 @@ class SerializableType(DictionaryType):
 
         def items_generator():
             """Generator of items"""
-            for (
-                member_name,
-                member_value,
-                member_format,
-                member_desc,
-            ) in self.MEMBER_LIST:
+            for member_name, _, _, _ in self.MEMBER_LIST:
                 yield member_name, self._val.get(member_name)
 
         return items_generator()

--- a/src/fprime/common/models/serialize/serializable_type.py
+++ b/src/fprime/common/models/serialize/serializable_type.py
@@ -174,3 +174,11 @@ class SerializableType(DictionaryType):
             members[member_name] = {"format": member_format, "description": member_desc}
             members[member_name].update(value)
         return members
+
+    def items(self):
+        """ Allow dictionary like iteration """
+        def items_generator():
+            """ Generator of items """
+            for member_name, member_value, member_format, member_desc in self.MEMBER_LIST:
+                yield member_name, self._val.get(member_name)
+        return items_generator()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds iterators to ArrayTypes and SerializeableTypes.

```python
for i in my_array:
   ....

for f, v in my_serializable.items():
```