### PR TITLE
Update gcovr.py

### DIFF
--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -91,6 +91,8 @@ class Gcovr(ExecutableAction):
             None if include_test_ac else ".*/.*GTestBase.[ch]pp",
             None if include_test_ac else ".*/.*TesterBase.[ch]pp",
             None if include_test_ac else ".*/.*TesterHelpers.[ch]pp",
+            None if include_test_ac else ".*\/.*StateMachineAc.[ch]pp",
+
         ]
         raw_source_exclusion_filter_bases = [
             None if include_test else ".*/test/ut/.*",

--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -91,8 +91,7 @@ class Gcovr(ExecutableAction):
             None if include_test_ac else ".*/.*GTestBase.[ch]pp",
             None if include_test_ac else ".*/.*TesterBase.[ch]pp",
             None if include_test_ac else ".*/.*TesterHelpers.[ch]pp",
-            None if include_test_ac else ".*\/.*StateMachineAc.[ch]pp",
-
+            None if include_test_ac else ".*/.*StateMachineAc.[ch]pp",
         ]
         raw_source_exclusion_filter_bases = [
             None if include_test else ".*/test/ut/.*",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added StateMachineAc.[ch]pp to the exclusion list in gcovr.py to prevent auto-generated files from affecting test coverage metrics.

## Rationale
Fixes nasa/fprime#3553

