### PR TITLE
Replace `--ninja` With `--make`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,18 +40,18 @@ jobs:
       - name: Test generation and building on Ref
         working-directory: fprime/Ref
         run: |
-          fprime-util generate
+          fprime-util generate --make
           fprime-util build
           fprime-util hash-to-file 0x72ad3277
       - name: Test generation and building on Ref with Ninja
         working-directory: fprime/Ref
         run: |
-          fprime-util generate --ninja --build-cache ./build-ninja
+          fprime-util generate --build-cache ./build-ninja
           fprime-util build --build-cache ./build-ninja
           fprime-util hash-to-file 0x72ad3277 --build-cache ./build-ninja
       - name: Test special generation on Ref
         working-directory: fprime/Ref
         run: |
-          fprime-util generate --build-cache ./special-cache --ut -DFPRIME_ENABLE_AUTOCODER_UTS=OFF
+          fprime-util generate --make --build-cache ./special-cache --ut -DFPRIME_ENABLE_AUTOCODER_UTS=OFF
           fprime-util build --build-cache ./special-cache
           fprime-util hash-to-file 0x2ed4bda6 --build-cache ./special-cache

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -1,4 +1,4 @@
-""" fprime.fbuild.cli: fbuild command line processing
+"""fprime.fbuild.cli: fbuild command line processing
 
 Command line processing functions for fbuild (fprime build system targets) of "generate", "purge", and build system
 target operations.
@@ -64,14 +64,14 @@ def run_fbuild_cli(
             cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = "OFF"
         if toolchain is not None:
             cmake_args["CMAKE_TOOLCHAIN_FILE"] = toolchain
-        
+
         if parsed.make:
             # No need to change CMAKE_GENERATOR since the default is Unix Makefiles
             pass
         else:
             # Sets Ninja as the default build system
             cmake_args["CMAKE_GENERATOR"] = "Ninja"
-        
+
         build.generate(cmake_args)
     elif parsed.command == "purge":
         # Since purge does not load its "base", we need to overload the platform

--- a/src/fprime/fbuild/cli.py
+++ b/src/fprime/fbuild/cli.py
@@ -64,8 +64,14 @@ def run_fbuild_cli(
             cmake_args["ENABLE_SANITIZER_UNDEFINED_BEHAVIOR"] = "OFF"
         if toolchain is not None:
             cmake_args["CMAKE_TOOLCHAIN_FILE"] = toolchain
-        if parsed.ninja:
+        
+        if parsed.make:
+            # No need to change CMAKE_GENERATOR since the default is Unix Makefiles
+            pass
+        else:
+            # Sets Ninja as the default build system
             cmake_args["CMAKE_GENERATOR"] = "Ninja"
+        
         build.generate(cmake_args)
     elif parsed.command == "purge":
         # Since purge does not load its "base", we need to overload the platform
@@ -248,9 +254,9 @@ def add_special_targets(
         action="store_true",
     )
     generate_parser.add_argument(
-        "--ninja",
+        "--make",
         action="store_true",
-        help="Use the Ninja build system instead of Unix Makefiles",
+        help="Use the Unix Makefiles build system instead of Ninja",
     )
     # The following option is specified only to show up in --help.
     # It is not handled by argparse, but in fprime.util.cli:validate()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [Issue #3594](https://github.com/nasa/fprime/issues/3594) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
### `src/fprime/fbuild/cli.py`
- Added a condition to not change the `CMAKE_GENERATOR` value if there is `--make` else `fprime-util generate` defaults to Ninja

- Changed the argument `--ninja` to `--make` and its help description

### `.github/workflows/integration-tests.yml`
- Fixed the arguments for Ninja being the default build system

## Rationale

Fixes [Replace `--ninja` With `--make` #3594](https://github.com/nasa/fprime/issues/3594)

## Testing/Review Recommendations

N/A

## Future Work

None
