### PR TITLE
Add `--dirs` and `--check` option to `format` command

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -100,5 +100,6 @@ usec
 useconds
 usr
 viewcode
+Werror
 workdir
 wxgui

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -1,4 +1,4 @@
-""" fprime.util.cli: CLI handling
+"""fprime.util.cli: CLI handling
 
 Defines main entrypoint for fprime-util and sets up parsers for general CLI targets.
 
@@ -203,7 +203,9 @@ def add_special_parsers(
         conflict_handler="resolve",
     ).add_argument_group("format utility arguments")
     format_parser.add_argument(
-        "--backup", action="store_true", help="Creates a .bak backup file for each formatted file"
+        "--backup",
+        action="store_true",
+        help="Creates a .bak backup file for each formatted file",
     )
     format_parser.add_argument(
         "-q", "--quiet", action="store_true", help="Disable clang-format verbose mode"

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -203,7 +203,7 @@ def add_special_parsers(
         conflict_handler="resolve",
     ).add_argument_group("format utility arguments")
     format_parser.add_argument(
-        "-x", "--no-backup", action="store_true", help="Disable backups"
+        "--backup", action="store_true", help="Creates a .bak backup file for each formatted file"
     )
     format_parser.add_argument(
         "-q", "--quiet", action="store_true", help="Disable clang-format verbose mode"
@@ -228,7 +228,20 @@ def add_special_parsers(
         help="List of files to format",
     )
     format_parser.add_argument(
+        "-d",
+        "--dirs",
+        nargs="*",
+        default=[],
+        type=Path,
+        help="List of directories to format, recursively searching for files matching allowed extensions",
+    )
+    format_parser.add_argument(
         "--stdin", action="store_true", help="Read stdin for list of files to format"
+    )
+    format_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if files are formatted correctly instead of formatting them",
     )
     format_parser.add_argument(
         "--pass-through",

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -49,7 +49,7 @@ class ClangFormatter(ExecutableAction):
         super().__init__(TargetScope.LOCAL)
         self.executable = executable
         self.style_file = style_file
-        self.backup = options.get("backup", True)
+        self.backup = options.get("backup", False)
         self.verbose = options.get("verbose", False)
         self.quiet = options.get("quiet", False)
         self.check = options.get("check", False)

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -52,6 +52,7 @@ class ClangFormatter(ExecutableAction):
         self.backup = options.get("backup", True)
         self.verbose = options.get("verbose", False)
         self.quiet = options.get("quiet", False)
+        self.check = options.get("check", False)
         self.validate_extensions = options.get("validate_extensions", True)
         self.allowed_extensions = ALLOWED_EXTENSIONS.copy()
         self._files_to_format: List[Path] = []
@@ -135,8 +136,8 @@ class ClangFormatter(ExecutableAction):
                 "Override location with --pass-through --style=file:<path>."
             )
             return 1
-        # Backup files unless --no-backup is requested
-        if self.backup:
+        # Backup files unless --no-backup is requested or running only a --check
+        if self.backup and not self.check:
             for file in self._files_to_format:
                 shutil.copy2(file, file.parent / f"{file.stem}.bak{file.suffix}")
         pass_through = args[1]
@@ -146,6 +147,7 @@ class ClangFormatter(ExecutableAction):
             "-i",
             f"--style=file",
             *(["--verbose"] if not self.quiet else []),
+            *(["--dry-run", "--Werror"] if self.check else []),
             *pass_through,
             *self._files_to_format,
         ]

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -1,4 +1,4 @@
-""" fprime.fbuild.code_formatter
+"""fprime.fbuild.code_formatter
 
 Wrapper for clang-format utility.
 

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -1,4 +1,4 @@
-""" fprime.util.commands: General-purpose command definitions
+"""fprime.util.commands: General-purpose command definitions
 
 Defines general-purpose command processing. Those are commands that do not belong in fbuild or fpp.
 Current commands include:

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -167,8 +167,9 @@ def run_code_format(
     options = {
         "quiet": parsed.quiet,
         "verbose": parsed.verbose,
-        "backup": not parsed.no_backup,
+        "backup": parsed.backup,
         "validate_extensions": not parsed.force,
+        "check": parsed.check,
     }
     clang_formatter = ClangFormatter(
         "clang-format",
@@ -191,6 +192,15 @@ def run_code_format(
     # Stage all files that are passed through --files
     for filename in parsed.files:
         clang_formatter.stage_file(Path(filename))
+    # Search for files within --dirs and stage them
+    for dirname in parsed.dirs:
+        dir_path = Path(dirname)
+        if not dir_path.is_dir():
+            print(f"[INFO] {dir_path} is not a directory. Skipping.")
+            continue
+        for allowed_ext in clang_formatter.allowed_extensions:
+            for file in dir_path.rglob(f"*{allowed_ext}"):
+                clang_formatter.stage_file(file)
     return clang_formatter.execute(build, parsed.path, ({}, parsed.pass_through))
 
 

--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -1,4 +1,4 @@
-""" fprime.util.help_text:
+"""fprime.util.help_text:
 
 Contains the strings and minor constructs used to specify help text in fprime utility. Any new help strings for new
 commands should be written here. Implementers should use HelpText.long(key) and HelpText.short(key) to get appropriate

--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -312,6 +312,9 @@ Examples:
   {EXECUTABLE} format -f Main.cpp Main.hpp
   {EXECUTABLE} format -f Imu/*
   {EXECUTABLE} format -f *.hpp --pass-through --dry-run
+
+  -- Format all files in a given directory -- 
+  {EXECUTABLE} format --dirs Svc Fw Drv
   
   -- From stdin using Git | format all changed files --
   git diff --name-only --relative | {EXECUTABLE} format --stdin


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds in `--dirs` and `--check` option. Also switches the `backup` option to false because it's annoying 😬 

Allows the following:

```bash
fprime-util format --check --dirs Svc Fw
```

Checks for formatting of CPP files recursively

## Rationale 

For CI testing