### PR TITLE
Update urllib3 dependency to >=2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pytest>=6.2.4",
     "cookiecutter>=2.2.3",
     "gcovr>=6.0",
-    "urllib3<2.0.0",
+    "urllib3>=2.5.0",
     "requests>=2.31.0",
 ]
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remove pin from urllib3 version. Used to be an issue - see https://github.com/nasa/fprime-tools/pull/141 for why the pin.
The underlying issue should have been fixed now.
