### PR TITLE
Fix usage of build object

### DIFF
--- a/src/fprime/fpp/impl.py
+++ b/src/fprime/fpp/impl.py
@@ -12,15 +12,14 @@ from pathlib import Path
 
 from typing import TYPE_CHECKING, Callable, Dict, List, Tuple
 
-if TYPE_CHECKING:
-    from fprime.fbuild.builder import Build
+from fprime.fbuild.builder import Build
 
 from fprime.fpp.common import FppUtility
 from fprime.util.code_formatter import ClangFormatter
 from fprime.constants import UT_FILES_TARGET_PATH, UT_TEMPLATE_FILE_SUFFIX
 
 
-def _apply_clang_formatting(framework_path, files_dir, generated_file_names):
+def _apply_clang_formatting(build: Build, framework_path: Path, files_dir: Path, generated_file_names: list[Path]):
     """
     Format files if clang-format is available.
 
@@ -36,7 +35,7 @@ def _apply_clang_formatting(framework_path, files_dir, generated_file_names):
         if clang_formatter.is_supported():
             for file_name in generated_file_names:
                 clang_formatter.stage_file(files_dir / file_name)
-            clang_formatter.execute(None, None, ({}, []))
+            clang_formatter.execute(build, None, ({}, []))
     else:
         print(
             f"[INFO] .clang-format file not found at {format_file.resolve()}. Skipping formatting."
@@ -69,7 +68,7 @@ def _move_ut_templates(files_dir, generated_file_names):
 
 
 def fpp_generate_implementation(
-    build: "Build",
+    build: Build,
     output_dir: Path,
     context: Path,
     apply_formatting: bool,
@@ -128,7 +127,7 @@ def fpp_generate_implementation(
     ]
 
     if apply_formatting:
-        _apply_clang_formatting(framework_path, output_dir, generated_file_names)
+        _apply_clang_formatting(build, framework_path, output_dir, generated_file_names)
 
     if generate_ut:
         _move_ut_templates(output_dir, generated_file_names)
@@ -137,7 +136,7 @@ def fpp_generate_implementation(
 
 
 def run_fpp_impl(
-    build: "Build",
+    build: Build,
     parsed: argparse.Namespace,
     _: Dict[str, str],
     __: Dict[str, str],

--- a/src/fprime/fpp/impl.py
+++ b/src/fprime/fpp/impl.py
@@ -1,4 +1,4 @@
-""" fprime.fpp.impl: Command line targets for `fprime-util impl`
+"""fprime.fpp.impl: Command line targets for `fprime-util impl`
 
 Processing and CLI entry points for `fprime-util impl` command line tool.
 
@@ -19,7 +19,12 @@ from fprime.util.code_formatter import ClangFormatter
 from fprime.constants import UT_FILES_TARGET_PATH, UT_TEMPLATE_FILE_SUFFIX
 
 
-def _apply_clang_formatting(build: Build, framework_path: Path, files_dir: Path, generated_file_names: list[Path]):
+def _apply_clang_formatting(
+    build: Build,
+    framework_path: Path,
+    files_dir: Path,
+    generated_file_names: list[Path],
+):
     """
     Format files if clang-format is available.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix usage of the build object (was None) during clang-format after the `impl` step

Broke in CI https://github.com/nasa/fprime/actions/runs/15908676986/job/44870194090

```
    Choose from [1/2] (1): 1
[INFO] Found CMake file at 'MyProject/project.cmake'
Add MyComponent to MyProject/project.cmake at end of file? (yes/no) [yes]: yes
Generate implementation files? (yes/no) [yes]: yes
Refreshing cache and generating implementation files...
Error:  'NoneType' object has no attribute 'settings'
expect: spawn id exp3 not open
    while executing
"expect eof"
    (file "./lib/fprime/.github/actions/cookiecutter-check/component.expect" line 24)
Error: Process completed with exit code 1.
```