### PR TITLE
Update new component to catch top-level namespace

### DIFF
--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -119,7 +119,11 @@ def new_component(build: Build, parsed_args: "argparse.Namespace"):
         # Use current working directory name as default namespace, unless at project root
         extra_context = {}
         if not proj_root.samefile(Path.cwd()):
-            extra_context["component_namespace"] = Path.cwd().name
+            cwd = Path.cwd()
+            # If in default Components directory, use parent directory name, which should be the top level namespace directory
+            extra_context["component_namespace"] = (
+                cwd.parent.name if cwd.name == "Components" else cwd.name
+            )
 
         gen_path = Path(cookiecutter(source, extra_context=extra_context)).resolve()
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adapting `new --component` to catch the top-level namespace above `Components/` directory when used in this common case. A little bit of a hacky solution but it's good enough imo.... alternative would be to have the build keep track of the top-level namespace which could be useful but we can't guarantee that it exists in the first place... 