### PR TITLE
Build dir fix

### DIFF
--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -118,9 +118,13 @@ class Build:
 
         if skip_validation:
             return
-        if (
-            self.build_dir is not None
-            and (self.build_dir / ".fprime-build-dir").exists()
+        # Validate this is a build cache by finding either of two known files
+        # One is from F´, other from CMake, for redundancy
+        if self.build_dir is not None and (
+            (
+                (self.build_dir / ".fprime-build-dir").exists()
+                or (self.build_dir / "CMakeCache.txt").exists()
+            )
         ):
             return
 

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -121,10 +121,8 @@ class Build:
         # Validate this is a build cache by finding either of two known files
         # One is from F´, other from CMake, for redundancy
         if self.build_dir is not None and (
-            (
-                (self.build_dir / ".fprime-build-dir").exists()
-                or (self.build_dir / "CMakeCache.txt").exists()
-            )
+            (self.build_dir / ".fprime-build-dir").exists()
+            or (self.build_dir / "CMakeCache.txt").exists()
         ):
             return
 

--- a/src/fprime/util/cookiecutter_wrapper.py
+++ b/src/fprime/util/cookiecutter_wrapper.py
@@ -119,7 +119,11 @@ def new_component(build: Build, parsed_args: "argparse.Namespace"):
         # Use current working directory name as default namespace, unless at project root
         extra_context = {}
         if not proj_root.samefile(Path.cwd()):
-            extra_context["component_namespace"] = Path.cwd().name
+            cwd = Path.cwd()
+            # If in default Components directory, use parent directory name, which should be the top level namespace directory
+            extra_context["component_namespace"] = (
+                cwd.parent.name if cwd.name == "Components" else cwd.name
+            )
 
         gen_path = Path(cookiecutter(source, extra_context=extra_context)).resolve()
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/4032

Update logic for validation that a directory is indeed an F´-CMake build dir by finding either of two known files that are known to be present in a build cache. The reason that finding one or the other is appropriate here imo is the following:
- in the case that the build cache is generated by an IDE, the `.fprime-build-dir` file is not present. It it still ok to look for a CMakeCache.txt as that will indicate it's a CMake dir
- in the case that a user `Ctrl+C` the `fprime-util generate` process too early, it is possible `CMakeCache.txt` has not been generated yet, but `.fprime-build-dir` will still indicate it's valid.

So two scenarios lead to situations where checking for either of the two is legitimate. Not the most elegant, but this is scenario-driven and I'd say appropriate.