### PR TITLE
Skip ctest invocation if no tests are requested

### DIFF
--- a/src/fprime/fbuild/check.py
+++ b/src/fprime/fbuild/check.py
@@ -70,6 +70,16 @@ class Check(EnumeratedAction):
             context and context != ["all"] and ".*" not in context
         ):
             cli_args.append("-V")
+
+        if not context:
+            # This only happens if the provided path does not contain tests
+            # and neither '--all' nor '--recursive' were provided
+            print(
+                "[INFO] No tests were found in the given context.",
+                "Did you mean to use `fprime-util check --recursive` or `--all` ?",
+            )
+            return
+
         # When not "all" append a regex to filter tests. .* works as a regex
         if context and context != ["all"]:
             test_regex = f"^({'|'.join(context)})$"

--- a/src/fprime/fbuild/check.py
+++ b/src/fprime/fbuild/check.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from typing import Tuple, Dict, List
 
-from fprime.fbuild.types import NoSuchTargetException
+from fprime.fbuild.types import NoTargetFoundException
 from fprime.fbuild.target import (
     TargetContext,
     TargetScope,
@@ -55,7 +55,7 @@ class Check(EnumeratedAction):
         if not context:
             # This only happens if the provided path does not contain tests
             # and neither '--all' nor '--recursive' were provided
-            raise NoSuchTargetException(
+            raise NoTargetFoundException(
                 "No tests were found in the given context. Did you mean to "
                 "use `fprime-util check --recursive` or `--all` ?"
             )

--- a/src/fprime/fbuild/check.py
+++ b/src/fprime/fbuild/check.py
@@ -50,6 +50,16 @@ class Check(EnumeratedAction):
         args: Tuple[Dict[str, str], List[str], Dict[str, bool]],
     ):
         """Execute this target"""
+
+        if not context:
+            # This only happens if the provided path does not contain tests
+            # and neither '--all' nor '--recursive' were provided
+            print(
+                "[ERROR] No tests were found in the given context.",
+                "Did you mean to use `fprime-util check --recursive` or `--all` ?",
+            )
+            sys.exit(1)
+
         cli_args = [
             self.EXECUTABLE,
             "--test-dir",
@@ -70,15 +80,6 @@ class Check(EnumeratedAction):
             context and context != ["all"] and ".*" not in context
         ):
             cli_args.append("-V")
-
-        if not context:
-            # This only happens if the provided path does not contain tests
-            # and neither '--all' nor '--recursive' were provided
-            print(
-                "[INFO] No tests were found in the given context.",
-                "Did you mean to use `fprime-util check --recursive` or `--all` ?",
-            )
-            return
 
         # When not "all" append a regex to filter tests. .* works as a regex
         if context and context != ["all"]:

--- a/src/fprime/fbuild/check.py
+++ b/src/fprime/fbuild/check.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from typing import Tuple, Dict, List
 
+from fprime.fbuild.types import NoSuchTargetException
 from fprime.fbuild.target import (
     TargetContext,
     TargetScope,
@@ -54,11 +55,10 @@ class Check(EnumeratedAction):
         if not context:
             # This only happens if the provided path does not contain tests
             # and neither '--all' nor '--recursive' were provided
-            print(
-                "[ERROR] No tests were found in the given context.",
-                "Did you mean to use `fprime-util check --recursive` or `--all` ?",
+            raise NoSuchTargetException(
+                "No tests were found in the given context. Did you mean to "
+                "use `fprime-util check --recursive` or `--all` ?"
             )
-            sys.exit(1)
 
         cli_args = [
             self.EXECUTABLE,

--- a/src/fprime/fbuild/types.py
+++ b/src/fprime/fbuild/types.py
@@ -36,6 +36,10 @@ class MissingBuildCachePath(FprimeException):
     """An exception indicating that a path in the build cache is missing"""
 
 
+class NoTargetFoundException(FprimeException):
+    """An exception indicating that no target was found in the given context"""
+
+
 class BuildType(Enum):
     """
     An enumeration used to represent the various build types used to build fprime. These types can support different


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix nasa/fprime#4012

If no tests are requested (path does not contain tests and neither `--recursive` nor `--all` provided), skip ctest invocation and log the unexpected behavior