### PR TITLE
Adjust task priorities to fit in supported platforms' priority ranges

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/instances.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/instances.fpp
@@ -29,22 +29,22 @@ module {{cookiecutter.deployment_name}} {
   instance rateGroup1: Svc.ActiveRateGroup base id 0x10001000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 120
+    priority 43
 
   instance rateGroup2: Svc.ActiveRateGroup base id 0x10002000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 119
+    priority 42
 
   instance rateGroup3: Svc.ActiveRateGroup base id 0x10003000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 118
+    priority 41
 
   instance cmdSeq: Svc.CmdSequencer base id 0x10004000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 117
+    priority 40
 
   # ----------------------------------------------------------------------
   # Queued component instances

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -27,7 +27,7 @@ U32 rateGroup2Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 U32 rateGroup3Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 
 enum TopologyConstants {
-    COMM_PRIORITY = 100,
+    COMM_PRIORITY = 23,
 };
 
 /**

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -27,7 +27,7 @@ U32 rateGroup2Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 U32 rateGroup3Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 
 enum TopologyConstants {
-    COMM_PRIORITY = 23,
+    COMM_PRIORITY = 34,
 };
 
 /**

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}Config/{{cookiecutter.subtopology_name}}Config.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-subtopology/{{cookiecutter.subtopology_name}}/{{cookiecutter.subtopology_name}}Config/{{cookiecutter.subtopology_name}}Config.fpp
@@ -17,7 +17,7 @@ module {{cookiecutter.subtopology_name}}Config {
     # Priorities for active components
     module Priorities {
         # Add your component priorities here. For example:
-        # constant myComponent = 100
+        # constant myComponent = 23
     }
 
     # Additional configuration modules can be added here as needed


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [fprime #3985](https://github.com/nasa/fprime/issues/3985) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Adjusted all task priorities throughout the framework so that they fit within the most-restrictive task priority range among supported platforms, which was determined to be Darwin's [15,47]. See the linked issue for that analysis. Within fprime-tools, this resulted in changes in the deployment and subtopology cookie-cutters.

Priority changes in the fprime repository are handled in [fprime PR #4337](https://github.com/nasa/fprime/pull/4337).

## Rationale

Previous task priorities were out of the valid range for the Linux and Darwin platforms, clamping tasks to the maximum priority and preventing differentiation of priority between some threads. Accordingly, priority clamp warnings were being (correctly) produced to the Logger when starting F Prime.

## Testing/Review Recommendations

No automated tests were added. The changes were verified by creating a new F Prime project, starting by cloning the candidate branch of fprime from my fork (https://github.com/pjromano/fprime/tree/fix-task-priorities); installing Python requirements; uninstalling fprime-tools and then installing this request's candidate version of fprime-tools (installed per https://github.com/nasa/fprime-tools/blob/devel/README.md#developer-installation), and then using `fprime-util new --deployment`. Verification was done by inspecting the active components' priorities in the new deployment's topology instances FPP and the COMM_PRIORITY in topology CPP; and then building and running the F Prime deployment and verifying that the log output does not contain "task priority" (text from the clamped warning).

## Future Work

None identified.
