### PR TITLE
Support --exclude option on fprime-util format

### DIFF
--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -256,7 +256,7 @@ def add_special_parsers(
         nargs="+",
         default=[],
         type=Path,
-        help="Exclude directories from formatting",
+        help="Exclude paths from formatting, taking precedence over all input mechanisms",
     )
 
     return {

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -251,6 +251,14 @@ def add_special_parsers(
         default=[],
         help="If specified, --pass-through must be the last argument. Remaining arguments passed to underlying executable",
     )
+    format_parser.add_argument(
+        "--exclude",
+        nargs="+",
+        default=[],
+        type=Path,
+        help="Exclude directories from formatting"
+    )
+    
     return {
         "hash-to-file": run_hash_to_file,
         "info": run_info,

--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -256,9 +256,9 @@ def add_special_parsers(
         nargs="+",
         default=[],
         type=Path,
-        help="Exclude directories from formatting"
+        help="Exclude directories from formatting",
     )
-    
+
     return {
         "hash-to-file": run_hash_to_file,
         "info": run_info,

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -85,8 +85,7 @@ class ClangFormatter(ExecutableAction):
             if self.verbose:
                 print(f"[INFO] Excluding {filepath} from formatting.")
             self._files_to_format.remove(filepath)
-        else:
-            if self.verbose:
+        elif self.verbose:
                 print(f"[INFO] {filepath} was not staged for formatting. Skipping.")
 
     def execute(

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -79,12 +79,15 @@ class ClangFormatter(ExecutableAction):
         it will be excluded to clang-format when the execute() function is called.
 
         Args:
-            filepath (str): file path to file to be excluded.
+            filepath (str): file path to be excluded.
         """
         if filepath in self._files_to_format:
             if self.verbose:
                 print(f"[INFO] Excluding {filepath} from formatting.")
             self._files_to_format.remove(filepath)
+        else:
+            if self.verbose:
+                print(f"[INFO] {filepath} was not staged for formatting. Skipping.")
 
     def execute(
         self, builder: "Build", context: "Path", args: Tuple[Dict[str, str], List[str]]

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -73,6 +73,20 @@ class ClangFormatter(ExecutableAction):
         else:
             self._files_to_format.append(filepath)
 
+    def exclude_file(self, filepath: Path) -> None:
+        """Request ClangFormatter to exclude the file for formatting.
+        If the file exists and its extension matches a known C/C++ format,
+        it will be excluded to clang-format when the execute() function is called.
+
+        Args:
+            filepath (str): file path to file to be excluded.
+        """
+        if not filepath.is_file():
+            if self.verbose:
+                print(f"[INFO] Skipping {filepath} : is not a file.")
+        elif filepath in self._files_to_format:
+            self._files_to_format.remove(filepath)
+
     def execute(
         self, builder: "Build", context: "Path", args: Tuple[Dict[str, str], List[str]]
     ):

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -86,7 +86,7 @@ class ClangFormatter(ExecutableAction):
                 print(f"[INFO] Excluding {filepath} from formatting.")
             self._files_to_format.remove(filepath)
         elif self.verbose:
-                print(f"[INFO] {filepath} was not staged for formatting. Skipping.")
+            print(f"[INFO] {filepath} was not staged for formatting. Skipping.")
 
     def execute(
         self, builder: "Build", context: "Path", args: Tuple[Dict[str, str], List[str]]

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -81,10 +81,9 @@ class ClangFormatter(ExecutableAction):
         Args:
             filepath (str): file path to file to be excluded.
         """
-        if not filepath.is_file():
+        if filepath in self._files_to_format:
             if self.verbose:
-                print(f"[INFO] Skipping {filepath} : is not a file.")
-        elif filepath in self._files_to_format:
+                print(f"[INFO] Excluding {filepath} from formatting.")
             self._files_to_format.remove(filepath)
 
     def execute(

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -201,9 +201,9 @@ def run_code_format(
         for allowed_ext in clang_formatter.allowed_extensions:
             for file in dir_path.rglob(f"*{allowed_ext}"):
                 clang_formatter.stage_file(file)
-    # Remove staged files that are within excluded directories
-    for excluded_dir in parsed.exclude:
-        excluded_path = Path(excluded_dir)
+    # Remove staged files that are within excluded paths
+    for excluded in parsed.exclude:
+        excluded_path = Path(excluded)
         if excluded_path.is_file():
             clang_formatter.exclude_file(excluded_path)
         elif excluded_path.is_dir():

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -202,7 +202,7 @@ def run_code_format(
             for file in dir_path.rglob(f"*{allowed_ext}"):
                 clang_formatter.stage_file(file)
     # Remove staged files that are within excluded directories
-    for excluded_dir in parsed.excluded:
+    for excluded_dir in parsed.exclude:
         excluded_path = Path(excluded_dir)
         if not excluded_path.is_dir():
             print(f"[INFO] {excluded_path} is not a directory. Skipping it from excluded directories.")

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -192,11 +192,16 @@ def run_code_format(
     # Stage all files that are passed through --files
     for filename in parsed.files:
         clang_formatter.stage_file(Path(filename))
+    # List all excluded directories
+    excluded_dirs = [Path(directory) for directory in parsed.exclude]
     # Search for files within --dirs and stage them
     for dirname in parsed.dirs:
         dir_path = Path(dirname)
         if not dir_path.is_dir():
             print(f"[INFO] {dir_path} is not a directory. Skipping.")
+            continue
+        if dir_path in excluded_dirs:
+            print(f"[INFO] Excluded {dir_path} from formatting.")
             continue
         for allowed_ext in clang_formatter.allowed_extensions:
             for file in dir_path.rglob(f"*{allowed_ext}"):

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -204,14 +204,15 @@ def run_code_format(
     # Remove staged files that are within excluded directories
     for excluded_dir in parsed.exclude:
         excluded_path = Path(excluded_dir)
-        if not excluded_path.is_dir():
-            print(
-                f"[INFO] {excluded_path} is not a directory. Skipping it from excluded directories."
-            )
+        if excluded_path.is_file():
+            clang_formatter.exclude_file(excluded_path)
+        elif excluded_path.is_dir():
+            for allowed_ext in clang_formatter.allowed_extensions:
+                for file in excluded_path.rglob(f"*{allowed_ext}"):
+                    clang_formatter.exclude_file(file)
+        else:
+            print(f"[INFO] {excluded_path} is not a valid path. Skipping.")
             continue
-        for allowed_ext in clang_formatter.allowed_extensions:
-            for file in excluded_path.rglob(f"*{allowed_ext}"):
-                clang_formatter.exclude_file(file)
 
     return clang_formatter.execute(build, parsed.path, ({}, parsed.pass_through))
 

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -205,7 +205,9 @@ def run_code_format(
     for excluded_dir in parsed.exclude:
         excluded_path = Path(excluded_dir)
         if not excluded_path.is_dir():
-            print(f"[INFO] {excluded_path} is not a directory. Skipping it from excluded directories.")
+            print(
+                f"[INFO] {excluded_path} is not a directory. Skipping it from excluded directories."
+            )
             continue
         for allowed_ext in clang_formatter.allowed_extensions:
             for file in excluded_path.rglob(f"*{allowed_ext}"):

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -192,20 +192,25 @@ def run_code_format(
     # Stage all files that are passed through --files
     for filename in parsed.files:
         clang_formatter.stage_file(Path(filename))
-    # List all excluded directories
-    excluded_dirs = [Path(directory) for directory in parsed.exclude]
     # Search for files within --dirs and stage them
     for dirname in parsed.dirs:
         dir_path = Path(dirname)
         if not dir_path.is_dir():
             print(f"[INFO] {dir_path} is not a directory. Skipping.")
             continue
-        if dir_path in excluded_dirs:
-            print(f"[INFO] Excluded {dir_path} from formatting.")
-            continue
         for allowed_ext in clang_formatter.allowed_extensions:
             for file in dir_path.rglob(f"*{allowed_ext}"):
                 clang_formatter.stage_file(file)
+    # Remove staged files that are within excluded directories
+    for excluded_dir in parsed.excluded:
+        excluded_path = Path(excluded_dir)
+        if not excluded_path.is_dir():
+            print(f"[INFO] {excluded_path} is not a directory. Skipping it from excluded directories.")
+            continue
+        for allowed_ext in clang_formatter.allowed_extensions:
+            for file in excluded_path.rglob(f"*{allowed_ext}"):
+                clang_formatter.exclude_file(file)
+
     return clang_formatter.execute(build, parsed.path, ({}, parsed.pass_through))
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [Support --exclude option on fprime-util format](https://github.com/nasa/fprime/issues/4022) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
`util/cli.py`
Added `--exclude` as an argument

`util/code_formatter.py`
Added `exclude_file()` function for removing staged files that are within the excluded directories

`util/commands.py`
Added an algorithm for excluding files from formatting

## Rationale
A requested feature for easily excluding files or directories where formatting is not needed.

## Testing/Review Recommendations
Run this command `fprime-util format --check --dirs . --exclude lib/fprime/googletest`

## Future Work
None
