### PR TITLE
make toolchain missing/duplicate errors more readable

### DIFF
--- a/src/fprime/common/models/serialize/type_base.py
+++ b/src/fprime/common/models/serialize/type_base.py
@@ -7,7 +7,6 @@ Replaced type base class with decorators
 
 import warnings
 
-
 warnings.warn(
     "TypeBase is defined in fprime_gds.common.models.serialize.type_base. Change your imports accordingly.",
     DeprecationWarning,

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -297,12 +297,12 @@ class Build:
         )
 
         if not toolchains:
-            searched_toolchain_paths = "\n\n" + '\n'.join(toolchains_paths)
-            msg = f"Could not find any toolchain file called {self.platform} at any of the following locations: {searched_toolchain_paths}"
+            searched_toolchain_paths = '\n\n' + '\n'.join(path.removesuffix(f"{self.platform}.cmake") for path in toolchains_paths)
+            msg = f"Could not find any toolchain file called {self.platform} after attempting to search for the file at the following locations: {searched_toolchain_paths}"
             raise NoSuchToolchainException(msg)
         if len(toolchains) > 1:
-            conflicting_toolchain_paths = "\n\n" + '\n'.join(toolchains)
-            msg = f"Found conflicting toolchain files for {self.platform} at: {conflicting_toolchain_paths}"
+            conflicting_toolchain_paths = '\n\n' + '\n'.join(toolchains)
+            msg = f"Found conflicting toolchain files for the toolchain file called {self.platform} in the following locations: {conflicting_toolchain_paths}"
             raise AmbiguousToolchainException(msg)
         return toolchains[0]
 

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -297,7 +297,7 @@ class Build:
         )
 
         if not toolchains:
-            searched_toolchain_paths = '\n\n' + '\n'.join(path.removesuffix(f"{self.platform}.cmake") for path in toolchains_paths)
+            searched_toolchain_paths = '\n' + '\n'.join(path.removesuffix(f"{self.platform}.cmake") for path in toolchains_paths)
             msg = f"Could not find any toolchain file called {self.platform}.cmake after attempting to search for the file at the following locations: {searched_toolchain_paths}"
             raise NoSuchToolchainException(msg)
         if len(toolchains) > 1:

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -295,11 +295,14 @@ class Build:
                 if os.path.exists(toolchain_path)
             }
         )
+
         if not toolchains:
-            msg = f"Could not find toolchain file for {self.platform} at any of: {' '.join(toolchains_paths)}"
+            searched_toolchain_paths = "\n\n" + '\n'.join(toolchains_paths)
+            msg = f"Could not find any toolchain file called {self.platform} at any of the following locations: {searched_toolchain_paths}"
             raise NoSuchToolchainException(msg)
         if len(toolchains) > 1:
-            msg = f"Found conflicting toolchain files for {self.platform} at: {' '.join(toolchains)}"
+            conflicting_toolchain_paths = "\n\n" + '\n'.join(toolchains)
+            msg = f"Found conflicting toolchain files for {self.platform} at: {conflicting_toolchain_paths}"
             raise AmbiguousToolchainException(msg)
         return toolchains[0]
 

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -298,7 +298,7 @@ class Build:
 
         if not toolchains:
             searched_toolchain_paths = '\n\n' + '\n'.join(path.removesuffix(f"{self.platform}.cmake") for path in toolchains_paths)
-            msg = f"Could not find any toolchain file called {self.platform} after attempting to search for the file at the following locations: {searched_toolchain_paths}"
+            msg = f"Could not find any toolchain file called {self.platform}.cmake after attempting to search for the file at the following locations: {searched_toolchain_paths}"
             raise NoSuchToolchainException(msg)
         if len(toolchains) > 1:
             conflicting_toolchain_paths = '\n\n' + '\n'.join(toolchains)

--- a/src/fprime/fbuild/builder.py
+++ b/src/fprime/fbuild/builder.py
@@ -297,11 +297,13 @@ class Build:
         )
 
         if not toolchains:
-            searched_toolchain_paths = '\n' + '\n'.join(path.removesuffix(f"{self.platform}.cmake") for path in toolchains_paths)
+            searched_toolchain_paths = "\n" + "\n".join(
+                path.removesuffix(f"{self.platform}.cmake") for path in toolchains_paths
+            )
             msg = f"Could not find any toolchain file called {self.platform}.cmake after attempting to search for the file at the following locations: {searched_toolchain_paths}"
             raise NoSuchToolchainException(msg)
         if len(toolchains) > 1:
-            conflicting_toolchain_paths = '\n\n' + '\n'.join(toolchains)
+            conflicting_toolchain_paths = "\n\n" + "\n".join(toolchains)
             msg = f"Found conflicting toolchain files for the toolchain file called {self.platform} in the following locations: {conflicting_toolchain_paths}"
             raise AmbiguousToolchainException(msg)
         return toolchains[0]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
the paths that are printed out by the toolchain missing/duplicate error are barfed out onto the command line all in a single line, making it super hard to read quickly. 
|**_Has Unit Tests (y/n)_**|  |
no, but tested
|**_Documentation Included (y/n)_**|  |
n
---
## Change Description

for the toolchain missing error message, i changed it so it would specify the name of the toolchain file builder.py was looking for (not new) and the paths where the builder.py attempted to find the toolchain file. i also changed the formatting of the output for this error message by printing \n after every path output so all the paths wouldnt be printed out in a single line with only a space separating it. also changed the message a little bit to be clearer about what was attempted by builder.py.

for the toolchain duplicate error message, really all i did was print \n after every path output so again, all the paths wouldnt be printed all in one line with only a single space separating them. that's hard to read.

## Rationale

for an error like this that can easily be resolved, the associated error message shouldn't be so hard to read. having all the paths be printed on one single line with only a single space as its separator is hard on the eye. 


