### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
         - python-version: 3.13
           fprime-version: v3.4.3
         - python-version: 3.13
-          fprime-version: v3.5.1          
+          fprime-version: v3.5.1   
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install System dependencies
         run: |
-          python -m pip install --upgrade pip urllib3 setuptools_scm
+          python -m pip install --upgrade pip urllib3 setuptools setuptools_scm
           sudo apt-get install ninja-build
       - name: Clone fprime and install requirements.txt
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,11 @@ jobs:
         - python-version: 3.13
           fprime-version: v3.4.3
         - python-version: 3.13
-          fprime-version: v3.5.1   
+          fprime-version: v3.5.1
+        - python-version: 3.12
+          fprime-version: v3.4.3
+        - python-version: 3.12
+          fprime-version: v3.5.1
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install System dependencies
         run: |
-          python -m pip install --upgrade pip urllib3 setuptools setuptools_scm
+          python -m pip install --upgrade pip urllib3 setuptools_scm
           sudo apt-get install ninja-build
       - name: Clone fprime and install requirements.txt
         run: |


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

CI fails for newer versions of Python: https://github.com/nasa/fprime-tools/actions/runs/22917058525/job/66505187652

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Removing these old versions that are causing issues.