### PR TITLE
Fix --from-source bug

### DIFF
--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -135,8 +135,10 @@ def run_new(
         __: unused make arguments
         ___: unused pass through arguments
     """
-    if hasattr(parsed, "from_source"):
+    # if from_source is provided, generate a new module with it
+    if hasattr(parsed, "from_source") and parsed.from_source is not None:
         return new_module(build, parsed, parsed.from_source)
+    # Otherwise, determine what to generate based on the command
     if parsed.new_component:
         return new_component(build, parsed)
     if parsed.new_deployment:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

`hasattr(from_source)` is most often true, we need to additionally check that it's not the default value. Otherwise all new commands will always use the module template.

This bug crashes CI in core F´ https://github.com/nasa/fprime/actions/runs/24096364757/job/70295900262?pr=4966
