### PR TITLE
fprime-tools: deinit generated deployments during teardown

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp
@@ -126,5 +126,6 @@ void teardownTopology(const TopologyState& state) {
     cmdSeq.deallocateBuffer(mallocator);
 
     tearDownComponents(state);
+    deinitComponents(state);
 }
 };  // namespace {{cookiecutter.deployment_namespace}}

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.hpp
@@ -47,6 +47,8 @@ void setupTopology(const TopologyState& state);
  *   3. Stop the tasks not owned by active components
  *   4. Join to the tasks not owned by active components
  *   5. Deallocate other resources
+ *   6. Call the autocoded `tearDownComponents()` function to tear down component-owned resources
+ *   7. Call the autocoded `deinitComponents()` function to deinitialize components
  *
  * Step 1, 2, 3, and 4 must occur in-order as the tasks must be stopped before being joined. These tasks must be stopped
  * and joined before any active resources may be deallocated.

--- a/test/fprime/fbuild/test_new_deployment.py
+++ b/test/fprime/fbuild/test_new_deployment.py
@@ -13,6 +13,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from cookiecutter.main import cookiecutter
 from fprime.fbuild.builder import Build
 from fprime.util.cookiecutter_wrapper import new_deployment
 
@@ -118,6 +119,40 @@ class TestNewDeployment(unittest.TestCase):
         self.assertEqual(
             kwargs["extra_context"]["__include_path_prefix"], "Deployments/"
         )
+
+    def test_builtin_deployment_template_emits_deinit_components(self):
+        """Test that the builtin deployment template tears down and deinitializes."""
+        template_root = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "fprime"
+            / "cookiecutter_templates"
+            / "cookiecutter-fprime-deployment"
+        )
+        pythonpath = str(Path(__file__).resolve().parents[3] / "src")
+        render_root = Path(self.temp_dir) / "rendered"
+        render_root.mkdir()
+
+        with patch.dict(os.environ, {"PYTHONPATH": pythonpath}, clear=False):
+            deployment_path = Path(
+                cookiecutter(
+                    str(template_root),
+                    no_input=True,
+                    output_dir=str(render_root),
+                )
+            )
+        topology_path = (
+            deployment_path
+            / "Top"
+            / f"{deployment_path.name}Topology.cpp"
+        )
+        topology_text = topology_path.read_text(encoding="utf-8")
+
+        teardown_call = "tearDownComponents(state);"
+        deinit_call = "deinitComponents(state);"
+        self.assertIn(teardown_call, topology_text)
+        self.assertIn(deinit_call, topology_text)
+        self.assertLess(topology_text.index(teardown_call), topology_text.index(deinit_call))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this updates the generated deployment template so it follows the expected shutdown lifecycle.

today generated topologies call tearDownComponents(state), but stop there. That means new deployments are created with an incomplete teardown path, missnig the deinitComponents(state) call.

this change adds deinitComponents(state) to the generated topology teardown, updates the header comment, and adds a regresison test to make sure generated code keeps the corret order.

I validated this locally on WSL, and the new test covers exactly this generated output case.

if anyone has diferent conetxt on the shutdown order here, please take a look, but this seems like the right fix to keep generated deployments aligned with the intended component lifecylce.

Thanks! Dhiego Pagotto...
