### PR TITLE
Connect CmdDispatcher run port in topology cookiecutter

### DIFF
--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment-phased/{{cookiecutter.deployment_name}}/Top/topology.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment-phased/{{cookiecutter.deployment_name}}/Top/topology.fpp
@@ -107,7 +107,7 @@ module {{cookiecutter.deployment_namespace}} {
       rateGroup1.RateGroupMemberOut[2] -> systemResources.run
       rateGroup1.RateGroupMemberOut[3] -> ComCcsds.comQueue.run
       rateGroup1.RateGroupMemberOut[4] -> ComCcsds.aggregator.timeout
-      rateGroup1Comp.RateGroupMemberOut[5] -> CdhCore.cmdDisp.run
+      rateGroup1.RateGroupMemberOut[5] -> CdhCore.cmdDisp.run
 
       # Rate group 2
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2.CycleIn

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment-phased/{{cookiecutter.deployment_name}}/Top/topology.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment-phased/{{cookiecutter.deployment_name}}/Top/topology.fpp
@@ -107,6 +107,7 @@ module {{cookiecutter.deployment_namespace}} {
       rateGroup1.RateGroupMemberOut[2] -> systemResources.run
       rateGroup1.RateGroupMemberOut[3] -> ComCcsds.comQueue.run
       rateGroup1.RateGroupMemberOut[4] -> ComCcsds.aggregator.timeout
+      rateGroup1Comp.RateGroupMemberOut[5] -> CdhCore.cmdDisp.run
 
       # Rate group 2
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2.CycleIn

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
@@ -107,7 +107,7 @@ module {{cookiecutter.deployment_namespace}} {
       rateGroup1.RateGroupMemberOut[2] -> systemResources.run
       rateGroup1.RateGroupMemberOut[3] -> ComCcsds.comQueue.run
       rateGroup1.RateGroupMemberOut[4] -> ComCcsds.aggregator.timeout
-      rateGroup1Comp.RateGroupMemberOut[5] -> CdhCore.cmdDisp.run
+      rateGroup1.RateGroupMemberOut[5] -> CdhCore.cmdDisp.run
 
       # Rate group 2
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2.CycleIn

--- a/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
+++ b/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/topology.fpp
@@ -107,6 +107,7 @@ module {{cookiecutter.deployment_namespace}} {
       rateGroup1.RateGroupMemberOut[2] -> systemResources.run
       rateGroup1.RateGroupMemberOut[3] -> ComCcsds.comQueue.run
       rateGroup1.RateGroupMemberOut[4] -> ComCcsds.aggregator.timeout
+      rateGroup1Comp.RateGroupMemberOut[5] -> CdhCore.cmdDisp.run
 
       # Rate group 2
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2.CycleIn


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

`cmdDisp.run` port emits telemetry. This wasn't connected, so reporting 0 telemetry. 