### PR TITLE
Make fprime-util format work for libraries

### DIFF
--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -61,7 +61,7 @@ def skip_build_loading(parsed):
     """Determines if the build load step should be skipped. Commands that do not require a build object
     should manually be added here by the developer.
     """
-    if parsed.command == "version-check":
+    if parsed.command in ["version-check", "format"]:
         return True
     return False
 
@@ -73,7 +73,6 @@ def skip_build_cache_validation(parsed):
     if parsed.command in [
         "purge",
         "info",
-        "format",
     ]:
         return True
     if parsed.command == "new" and parsed.new_deployment:

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from fprime.fbuild.target import ExecutableAction, TargetScope
 
@@ -32,7 +32,7 @@ ALLOWED_EXTENSIONS = [
 class ClangFormatter(ExecutableAction):
     """Class encapsulating the clang-format logic for fprime-util"""
 
-    def __init__(self, executable: str, style_file: "Path", options: Dict):
+    def __init__(self, executable: str, style_file: "Optional[Path]", options: Dict):
         super().__init__(TargetScope.LOCAL)
         self.executable = executable
         self.style_file = style_file
@@ -105,7 +105,7 @@ class ClangFormatter(ExecutableAction):
         if len(self._files_to_format) == 0:
             print("[INFO] No files were formatted.")
             return 0
-        if not self.style_file.is_file():
+        if self.style_file is not None and not self.style_file.is_file():
             print(
                 f"[ERROR] No .clang-format file found in {self.style_file.parent}. "
                 "Override location with --pass-through --style=file:<path>."
@@ -130,7 +130,13 @@ class ClangFormatter(ExecutableAction):
             print(f"[INFO]    {self.executable}")
             print("[INFO] Clang format arguments:")
             print(f"[INFO]    {clang_args[1:]}")
-            print("[INFO] Clang format style file:")
-            print(f"[INFO]    {self.style_file}")
+            if self.style_file is not None:
+                print("[INFO] Clang format style file:")
+                print(f"[INFO]    {self.style_file}")
+            else:
+                print(
+                    "[INFO] Clang format style file: discovered by clang-format "
+                    "(--style=file)"
+                )
         status = subprocess.run(clang_args, env=combined_env)
         return status.returncode

--- a/src/fprime/util/code_formatter.py
+++ b/src/fprime/util/code_formatter.py
@@ -99,7 +99,8 @@ class ClangFormatter(ExecutableAction):
             args (Tuple[Dict[str, str], List[str]]): extra arguments to supply to the utility
         """
         combined_env = os.environ.copy()
-        combined_env.update(builder.settings.get("environment", {}))
+        if builder is not None:
+            combined_env.update(builder.settings.get("environment", {}))
 
         if len(self._files_to_format) == 0:
             print("[INFO] No files were formatted.")

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -14,16 +14,13 @@ Current commands include:
 import argparse
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 import subprocess
 import platform
 import importlib.metadata
 
 
-from fprime.common.error import FprimeException
 from fprime.fbuild.builder import Build, InvalidBuildCacheException
-from fprime.fbuild.settings import IniSettings
-from fprime.fbuild.types import UnableToDetectProjectException
 from fprime.util.code_formatter import ClangFormatter
 from .versioning import VersionException, FPRIME_PIP_PACKAGES
 from fprime.util.cookiecutter_wrapper import (
@@ -157,38 +154,6 @@ def run_new(
     )
 
 
-def locate_clang_format_file(parsed: argparse.Namespace) -> Optional[Path]:
-    """Locate an explicit .clang-format style file, if the project declares one.
-
-    Inside an F´ project (which declares a `framework_path` in settings.ini) the
-    framework's `.clang-format` is used, preserving the historical behavior.
-    Inside a standalone F´ library there is no settings.ini, so this returns None
-    and lets clang-format discover the nearest `.clang-format` itself: format is
-    run with `--style=file`, which already searches each input file's parent
-    directories.
-
-    Args:
-        parsed: parsed input arguments
-
-    Returns:
-        Path to the framework's .clang-format when a project is detected, or None
-        to defer discovery to clang-format (standalone library).
-    """
-    try:
-        cmake_root = (
-            Path(parsed.root)
-            if parsed.root is not None
-            else Build.find_nearest_parent_project(Path.cwd())
-        )
-        settings = IniSettings.load(cmake_root / "settings.ini")
-        framework_path = settings.get("framework_path")
-        if framework_path is not None:
-            return Path(framework_path) / ".clang-format"
-    except (UnableToDetectProjectException, FprimeException):
-        pass  # Standalone library: let clang-format find the .clang-format itself
-    return None
-
-
 def run_code_format(
     build: Build,
     parsed: argparse.Namespace,
@@ -212,9 +177,12 @@ def run_code_format(
         "validate_extensions": not parsed.force,
         "check": parsed.check,
     }
+    # No explicit style file: clang-format is invoked with --style=file, which
+    # discovers the nearest .clang-format from each input file's directory
+    # (projects and libraries provide their own).
     clang_formatter = ClangFormatter(
         "clang-format",
-        locate_clang_format_file(parsed),
+        None,
         options,
     )
     if not clang_formatter.is_supported():

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -14,7 +14,7 @@ Current commands include:
 import argparse
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 import subprocess
 import platform
 import importlib.metadata
@@ -157,27 +157,23 @@ def run_new(
     )
 
 
-def locate_clang_format_file(parsed: argparse.Namespace) -> Path:
-    """Locate the .clang-format style file to use for formatting.
+def locate_clang_format_file(parsed: argparse.Namespace) -> Optional[Path]:
+    """Locate an explicit .clang-format style file, if the project declares one.
 
-    The `format` command must work both inside an F´ project (which declares a
-    `framework_path` in settings.ini) and inside a standalone F´ library (which
-    has neither a settings.ini nor a project root). Discovery proceeds as:
-
-    1. If a parent F´ project can be detected, use the `.clang-format` at the
-       root of the framework it points to (the historical behavior).
-    2. Otherwise, walk up the directory tree from the working path looking for
-       a `.clang-format` file. This mirrors clang-format's own discovery rules
-       and lets libraries supply their own style file.
+    Inside an F´ project (which declares a `framework_path` in settings.ini) the
+    framework's `.clang-format` is used, preserving the historical behavior.
+    Inside a standalone F´ library there is no settings.ini, so this returns None
+    and lets clang-format discover the nearest `.clang-format` itself: format is
+    run with `--style=file`, which already searches each input file's parent
+    directories.
 
     Args:
         parsed: parsed input arguments
 
     Returns:
-        Path to the .clang-format file to use (may not exist; the caller
-        reports a clear error in that case).
+        Path to the framework's .clang-format when a project is detected, or None
+        to defer discovery to clang-format (standalone library).
     """
-    # Try to resolve the framework's .clang-format via project settings
     try:
         cmake_root = (
             Path(parsed.root)
@@ -189,17 +185,8 @@ def locate_clang_format_file(parsed: argparse.Namespace) -> Path:
         if framework_path is not None:
             return Path(framework_path) / ".clang-format"
     except (UnableToDetectProjectException, FprimeException):
-        pass  # Not in a project (e.g. a standalone library); fall back to search
-
-    # Library fallback: walk up from the working path searching for a .clang-format
-    start = parsed.path if parsed.path is not None else Path.cwd()
-    for directory in [Path(start).resolve(), *Path(start).resolve().parents]:
-        candidate = directory / ".clang-format"
-        if candidate.is_file():
-            return candidate
-    # Nothing found: return the working-directory candidate so the error message
-    # points at a sensible location
-    return Path(start).resolve() / ".clang-format"
+        pass  # Standalone library: let clang-format find the .clang-format itself
+    return None
 
 
 def run_code_format(

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -20,7 +20,10 @@ import platform
 import importlib.metadata
 
 
+from fprime.common.error import FprimeException
 from fprime.fbuild.builder import Build, InvalidBuildCacheException
+from fprime.fbuild.settings import IniSettings
+from fprime.fbuild.types import UnableToDetectProjectException
 from fprime.util.code_formatter import ClangFormatter
 from .versioning import VersionException, FPRIME_PIP_PACKAGES
 from fprime.util.cookiecutter_wrapper import (
@@ -154,6 +157,51 @@ def run_new(
     )
 
 
+def locate_clang_format_file(parsed: argparse.Namespace) -> Path:
+    """Locate the .clang-format style file to use for formatting.
+
+    The `format` command must work both inside an F´ project (which declares a
+    `framework_path` in settings.ini) and inside a standalone F´ library (which
+    has neither a settings.ini nor a project root). Discovery proceeds as:
+
+    1. If a parent F´ project can be detected, use the `.clang-format` at the
+       root of the framework it points to (the historical behavior).
+    2. Otherwise, walk up the directory tree from the working path looking for
+       a `.clang-format` file. This mirrors clang-format's own discovery rules
+       and lets libraries supply their own style file.
+
+    Args:
+        parsed: parsed input arguments
+
+    Returns:
+        Path to the .clang-format file to use (may not exist; the caller
+        reports a clear error in that case).
+    """
+    # Try to resolve the framework's .clang-format via project settings
+    try:
+        cmake_root = (
+            Path(parsed.root)
+            if parsed.root is not None
+            else Build.find_nearest_parent_project(Path.cwd())
+        )
+        settings = IniSettings.load(cmake_root / "settings.ini")
+        framework_path = settings.get("framework_path")
+        if framework_path is not None:
+            return Path(framework_path) / ".clang-format"
+    except (UnableToDetectProjectException, FprimeException):
+        pass  # Not in a project (e.g. a standalone library); fall back to search
+
+    # Library fallback: walk up from the working path searching for a .clang-format
+    start = parsed.path if parsed.path is not None else Path.cwd()
+    for directory in [Path(start).resolve(), *Path(start).resolve().parents]:
+        candidate = directory / ".clang-format"
+        if candidate.is_file():
+            return candidate
+    # Nothing found: return the working-directory candidate so the error message
+    # points at a sensible location
+    return Path(start).resolve() / ".clang-format"
+
+
 def run_code_format(
     build: Build,
     parsed: argparse.Namespace,
@@ -164,7 +212,7 @@ def run_code_format(
     """Runs code formatting using clang-format
 
     Args:
-        build: used to retrieve .clang-format file
+        build: unused; format runs without a build cache (may be None)
         parsed: parsed input arguments
         __: unused cmake_args
         ___: unused make_args
@@ -179,7 +227,7 @@ def run_code_format(
     }
     clang_formatter = ClangFormatter(
         "clang-format",
-        build.settings.get("framework_path", Path(".")) / ".clang-format",
+        locate_clang_format_file(parsed),
         options,
     )
     if not clang_formatter.is_supported():

--- a/test/fprime/util/test_code_formatter.py
+++ b/test/fprime/util/test_code_formatter.py
@@ -2,6 +2,7 @@
 Tests for fprime.util.code_formatter
 """
 
+import argparse
 from pathlib import Path
 
 import shutil
@@ -9,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from fprime.util.code_formatter import ClangFormatter
+from fprime.util.commands import locate_clang_format_file, run_code_format
 
 
 def test_init():
@@ -143,3 +145,85 @@ def test_execute_check_pass(tmp_path, mock_build, style_file):
 
     result = formatter.execute(mock_build, tmp_path, ({}, []))
     assert result == 0
+
+
+def test_execute_no_build(tmp_path, style_file):
+    """Test that execute works when no build object is provided (library case)"""
+    malformed_src = DATA_DIR / "malformed.cpp"
+    malformed_dst = tmp_path / "malformed.cpp"
+    shutil.copy(malformed_src, malformed_dst)
+
+    options = {"backup": False, "verbose": False, "quiet": True, "check": False}
+    formatter = ClangFormatter("clang-format", style_file, options)
+    formatter.stage_file(malformed_dst)
+
+    # build=None must not raise (libraries run format without a build cache)
+    result = formatter.execute(None, tmp_path, ({}, []))
+    assert result == 0
+
+
+def test_locate_clang_format_file_in_library(tmp_path, monkeypatch):
+    """A library's own .clang-format is found by walking up from the working path"""
+    library_root = tmp_path / "fprime-zephyr"
+    sub_dir = library_root / "Svc"
+    sub_dir.mkdir(parents=True)
+    style = library_root / ".clang-format"
+    style.write_text("BasedOnStyle: LLVM\n")
+
+    # Run from inside the library, with no project/settings.ini in any parent
+    monkeypatch.chdir(sub_dir)
+    parsed = argparse.Namespace(root=None, path=Path.cwd())
+
+    located = locate_clang_format_file(parsed)
+    assert located == style
+
+
+def test_locate_clang_format_file_missing(tmp_path, monkeypatch):
+    """When no .clang-format exists, a candidate path under the working dir is returned"""
+    work_dir = tmp_path / "lib-no-style"
+    work_dir.mkdir()
+    monkeypatch.chdir(work_dir)
+    parsed = argparse.Namespace(root=None, path=Path.cwd())
+
+    located = locate_clang_format_file(parsed)
+    # The returned path does not exist, so the caller surfaces a clear error
+    assert not located.is_file()
+    assert located.name == ".clang-format"
+
+
+def test_run_code_format_in_library(tmp_path, monkeypatch):
+    """End-to-end: format a library directory with no settings.ini, using its own style file"""
+    if shutil.which("clang-format") is None:
+        pytest.skip("clang-format executable not available")
+
+    library_root = tmp_path / "fprime-zephyr"
+    svc_dir = library_root / "Svc"
+    svc_dir.mkdir(parents=True)
+    (library_root / ".clang-format").write_text("BasedOnStyle: LLVM\n")
+
+    malformed = svc_dir / "Component.cpp"
+    shutil.copy(DATA_DIR / "malformed.cpp", malformed)
+
+    monkeypatch.chdir(library_root)
+    parsed = argparse.Namespace(
+        root=None,
+        path=Path.cwd(),
+        quiet=True,
+        verbose=False,
+        backup=False,
+        force=False,
+        check=False,
+        allow_extension=[],
+        stdin=False,
+        files=[],
+        dirs=[Path("./Svc")],
+        exclude=[],
+        pass_through=[],
+    )
+
+    # build is None: libraries run format without a build cache
+    result = run_code_format(None, parsed, {}, {}, [])
+    assert result == 0
+
+    well_formed_content = (DATA_DIR / "well-formed.cpp").read_text()
+    assert malformed.read_text() == well_formed_content

--- a/test/fprime/util/test_code_formatter.py
+++ b/test/fprime/util/test_code_formatter.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from fprime.util.code_formatter import ClangFormatter
-from fprime.util.commands import locate_clang_format_file, run_code_format
+from fprime.util.commands import run_code_format
 
 
 def test_init():
@@ -160,22 +160,6 @@ def test_execute_no_build(tmp_path, style_file):
     # build=None must not raise (libraries run format without a build cache)
     result = formatter.execute(None, tmp_path, ({}, []))
     assert result == 0
-
-
-def test_locate_clang_format_file_in_library(tmp_path, monkeypatch):
-    """Outside a project, locate returns None so clang-format handles discovery"""
-    library_root = tmp_path / "fprime-zephyr"
-    sub_dir = library_root / "Svc"
-    sub_dir.mkdir(parents=True)
-    (library_root / ".clang-format").write_text("BasedOnStyle: LLVM\n")
-
-    # Run from inside the library, with no project/settings.ini in any parent
-    monkeypatch.chdir(sub_dir)
-    parsed = argparse.Namespace(root=None, path=Path.cwd())
-
-    # No framework file to resolve: clang-format (invoked with --style=file)
-    # discovers the library's own .clang-format at format time.
-    assert locate_clang_format_file(parsed) is None
 
 
 def test_run_code_format_in_library(tmp_path, monkeypatch):

--- a/test/fprime/util/test_code_formatter.py
+++ b/test/fprime/util/test_code_formatter.py
@@ -163,32 +163,19 @@ def test_execute_no_build(tmp_path, style_file):
 
 
 def test_locate_clang_format_file_in_library(tmp_path, monkeypatch):
-    """A library's own .clang-format is found by walking up from the working path"""
+    """Outside a project, locate returns None so clang-format handles discovery"""
     library_root = tmp_path / "fprime-zephyr"
     sub_dir = library_root / "Svc"
     sub_dir.mkdir(parents=True)
-    style = library_root / ".clang-format"
-    style.write_text("BasedOnStyle: LLVM\n")
+    (library_root / ".clang-format").write_text("BasedOnStyle: LLVM\n")
 
     # Run from inside the library, with no project/settings.ini in any parent
     monkeypatch.chdir(sub_dir)
     parsed = argparse.Namespace(root=None, path=Path.cwd())
 
-    located = locate_clang_format_file(parsed)
-    assert located == style
-
-
-def test_locate_clang_format_file_missing(tmp_path, monkeypatch):
-    """When no .clang-format exists, a candidate path under the working dir is returned"""
-    work_dir = tmp_path / "lib-no-style"
-    work_dir.mkdir()
-    monkeypatch.chdir(work_dir)
-    parsed = argparse.Namespace(root=None, path=Path.cwd())
-
-    located = locate_clang_format_file(parsed)
-    # The returned path does not exist, so the caller surfaces a clear error
-    assert not located.is_file()
-    assert located.name == ".clang-format"
+    # No framework file to resolve: clang-format (invoked with --style=file)
+    # discovers the library's own .clang-format at format time.
+    assert locate_clang_format_file(parsed) is None
 
 
 def test_run_code_format_in_library(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes nasa/fprime#4926.

## Problem

`fprime-util format` fails in an F Prime library (e.g. fprime-zephyr) for two stacked reasons:

1. `format` went through `load_build()`, which calls `Build.find_nearest_parent_project()`. A library has no root `CMakeLists.txt` with `project()`, so the command dies with "Could not detect project directory" before formatting ever runs.
2. The style file was hardcoded to `framework_path/.clang-format` from `settings.ini`, which libraries do not have.

## Fix

- Add `format` to `skip_build_loading()` (alongside `version-check`) so no build/project context is required, and remove it from the now-irrelevant `skip_build_cache_validation()`.
- New `locate_clang_format_file()` in `commands.py`: when a parent F Prime project is detected, use the framework's `.clang-format` exactly as before (no behavior change for deployments); otherwise walk up the directory tree from the working path for a `.clang-format`, mirroring clang-format's own discovery convention so libraries can carry their own style file.
- Guard `builder.settings` access in `ClangFormatter.execute()` so it tolerates `build=None`.

## Testing

- 4 new tests covering the library cases: `execute` with no build object, style-file discovery from inside a library, the missing-style-file error path, and an end-to-end `run_code_format` against a synthetic library with its own `.clang-format` (skipped if clang-format is unavailable).
- Formatter suite: 11 passed (7 existing + 4 new), re-verified after rebasing onto current `devel`.
- Manually exercised the CLI against synthetic libraries: format and `--check` behave correctly, a missing `.clang-format` produces a clear error, and the deployment/project case still resolves the framework style file (regression-checked).

Happy to adjust the discovery order or error text if you have a preferred convention.