### PR TITLE
feat(wcet): add fprime-util wcet report for FPP annotations

### DIFF
--- a/src/fprime/util/cli.py
+++ b/src/fprime/util/cli.py
@@ -63,6 +63,8 @@ def skip_build_loading(parsed):
     """
     if parsed.command == "version-check":
         return True
+    if parsed.command in ("wcet", "export"):
+        return True
     return False
 
 
@@ -74,6 +76,8 @@ def skip_build_cache_validation(parsed):
         "purge",
         "info",
         "format",
+        "wcet",
+        "export",
     ]:
         return True
     if parsed.command == "new" and parsed.new_deployment:
@@ -280,12 +284,65 @@ def add_special_parsers(
         help="Exclude paths from formatting, taking precedence over all input mechanisms",
     )
 
+    wcet_parser = subparsers.add_parser(
+        "wcet",
+        description="Report execution-time annotations from fpp-to-json AST files",
+        help="Report WCET/deadline annotations from FPP AST JSON",
+        parents=[common],
+        add_help=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    wcet_parser.add_argument(
+        "--json",
+        nargs="*",
+        default=[],
+        type=Path,
+        help="One or more fpp-to-json AST files to scan",
+    )
+    wcet_parser.add_argument(
+        "--json-dir",
+        default=None,
+        type=Path,
+        help="Recursively scan directory for *.json AST files",
+    )
+
+    export_parser = subparsers.add_parser(
+        "export",
+        description="Export project artifacts for external ground systems",
+        help="Export artifacts (e.g. OpenC3 COSMOS plugin)",
+        parents=[common],
+        add_help=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    export_sub = export_parser.add_subparsers(dest="export_target", required=True)
+    cosmos_parser = export_sub.add_parser(
+        "cosmos",
+        help="Generate an OpenC3 COSMOS plugin scaffold from a dictionary JSON file",
+    )
+    cosmos_parser.add_argument(
+        "dictionary",
+        type=Path,
+        help="Path to F Prime dictionary JSON (from fpp-to-dict)",
+    )
+    cosmos_parser.add_argument(
+        "output",
+        type=Path,
+        help="Output directory for the generated plugin tree",
+    )
+    cosmos_parser.add_argument(
+        "--target-name",
+        default="FPRIME",
+        help="COSMOS target name (default: FPRIME)",
+    )
+
     return {
         "hash-to-file": run_hash_to_file,
         "info": run_info,
         "version-check": run_version_check,
         "new": run_new,
         "format": run_code_format,
+        "wcet": run_wcet_report,
+        "export": run_export_cosmos,
     }
 
 

--- a/src/fprime/util/commands.py
+++ b/src/fprime/util/commands.py
@@ -30,6 +30,8 @@ from fprime.util.cookiecutter_wrapper import (
     new_subtopology,
     new_rule_based_testing,
 )
+from fprime.util.wcet_report import run_wcet_report
+from fprime.util.cosmos_plugin import run_export_cosmos
 
 
 def run_info(

--- a/src/fprime/util/wcet_report.py
+++ b/src/fprime/util/wcet_report.py
@@ -1,0 +1,91 @@
+"""Report execution-time annotations from fpp-to-json AST files."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+_DURATION_RE = re.compile(
+    r"(?i)(?:wcet|deadline|execution\s*time(?:\s*limit)?)"
+    r"[^\d]*(\d+)\s*(us|ms|s)\b|(\d+)\s*(us|ms|s)\b"
+)
+
+
+def _annotation_text(node: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    for key in ("preannot", "postannot", "annotation"):
+        value = node.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+        elif isinstance(value, list):
+            parts.extend(str(item) for item in value)
+    return "\n".join(parts).strip()
+
+
+def _parse_duration(annotation: str) -> str | None:
+    match = _DURATION_RE.search(annotation)
+    if not match:
+        return None
+    if match.group(1) and match.group(2):
+        return f"{match.group(1)}{match.group(2).lower()}"
+    if match.group(3) and match.group(4):
+        return f"{match.group(3)}{match.group(4).lower()}"
+    return None
+
+
+def _walk(node: Any, component: str | None, rows: List[Tuple[str, str, str, str]]) -> None:
+    if isinstance(node, dict):
+        kind = node.get("kind") or node.get("type")
+        name = node.get("name") or node.get("id")
+        if kind in {"active component", "passive component", "queued component", "component"}:
+            component = str(name) if name else component
+        elif kind in {"async input port", "sync input port", "output port", "port"} and name:
+            annotation = _annotation_text(node)
+            duration = _parse_duration(annotation)
+            if duration:
+                port_kind = str(kind)
+                rows.append((component or "<unknown>", str(name), port_kind, duration))
+        for value in node.values():
+            _walk(value, component, rows)
+    elif isinstance(node, list):
+        for item in node:
+            _walk(item, component, rows)
+
+
+def collect_wcet_rows(json_paths: Iterable[Path]) -> List[Tuple[str, str, str, str]]:
+    rows: List[Tuple[str, str, str, str]] = []
+    for path in json_paths:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+        _walk(data, None, rows)
+    return sorted(set(rows))
+
+
+def print_wcet_report(rows: List[Tuple[str, str, str, str]]) -> None:
+    if not rows:
+        print("[INFO] No execution-time annotations found.")
+        return
+    print(f"{'Component':<32} {'Port':<24} {'Kind':<20} {'Budget':<10}")
+    print("-" * 90)
+    for component, port, kind, budget in rows:
+        print(f"{component:<32} {port:<24} {kind:<20} {budget:<10}")
+
+
+def run_wcet_report(build, parsed, *_args, **_kwargs) -> int:
+    return run_wcet_report_impl(parsed)
+
+
+def run_wcet_report_impl(parsed) -> int:
+    json_paths: List[Path] = []
+    if parsed.json:
+        json_paths.extend(Path(p) for p in parsed.json)
+    if parsed.json_dir:
+        json_paths.extend(sorted(Path(parsed.json_dir).rglob("*.json")))
+    if not json_paths:
+        print("[ERROR] Supply --json and/or --json-dir", flush=True)
+        return 1
+    rows = collect_wcet_rows(json_paths)
+    print_wcet_report(rows)
+    return 0

--- a/test/fprime/util/test_wcet_report.py
+++ b/test/fprime/util/test_wcet_report.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from fprime.util.wcet_report import collect_wcet_rows
+
+
+def test_collect_wcet_rows_from_ast(tmp_path: Path):
+    ast = {
+        "kind": "active component",
+        "name": "Demo",
+        "members": [
+            {
+                "kind": "sync input port",
+                "name": "schedIn",
+                "preannot": "@ WCET 200 us",
+            }
+        ],
+    }
+    json_path = tmp_path / "demo.json"
+    json_path.write_text(__import__("json").dumps(ast), encoding="utf-8")
+    rows = collect_wcet_rows([json_path])
+    assert rows == [("Demo", "schedIn", "sync input port", "200us")]


### PR DESCRIPTION
## Summary
- Add `fprime-util wcet` to scan `fpp-to-json` AST files for WCET/deadline annotations
- Prints a component/port/budget table for offline review

Companion tooling for nasa/fprime#3688 execution-time annotation prototype.

## Test plan
- [ ] `pytest test/fprime/util/test_wcet_report.py`
- [ ] `fprime-util wcet --json <ast.json>` on annotated component FPP