### PR TITLE
Report gcovr's return code instead of discarding it

### DIFF
--- a/src/fprime/fbuild/gcovr.py
+++ b/src/fprime/fbuild/gcovr.py
@@ -201,7 +201,12 @@ class Gcovr(ExecutableAction):
             joined_args = "' '".join(cli_args)
             print(f"[INFO] Running \"'{ joined_args }'\"")
         # gcovr must run in the ac_temporary_path or html details cannot find the Ac files
-        subprocess.call(cli_args, env=combined_env)
+        return_code = subprocess.call(cli_args, env=combined_env)
+        if return_code != 0:
+            print(
+                f"[ERROR] gcovr exited with code {return_code}. Coverage results may be incomplete or missing.",
+                file=sys.stderr,
+            )
 
     def option_args(self):
         """Option arguments"""

--- a/test/fprime/fbuild/test_gcovr.py
+++ b/test/fprime/fbuild/test_gcovr.py
@@ -1,0 +1,63 @@
+"""Tests for fprime.fbuild.gcovr"""
+
+from unittest.mock import MagicMock, patch
+
+from fprime.fbuild.gcovr import Gcovr
+from fprime.fbuild.target import TargetScope
+
+
+def _mock_builder(tmp_path):
+    """A builder mock with just enough surface for Gcovr.execute() to run"""
+    builder = MagicMock()
+    builder.build_dir = tmp_path
+    builder.get_settings.side_effect = lambda key, default=None: default
+    builder.is_project_root.return_value = True
+    builder.settings = {}
+    builder.cmake.verbose = False
+    return builder
+
+
+def _gcovr_args():
+    """A minimal (make_args, pass_through_args, options) tuple accepted by Gcovr.execute()"""
+    options = {
+        "--all-sources": False,
+        "--comp-ac": False,
+        "--port-ac": False,
+        "--type-ac": False,
+        "--test-ac": False,
+        "--test-sources": False,
+    }
+    return ({}, [], options)
+
+
+def test_gcovr_reports_nonzero_return_code(tmp_path, capsys):
+    """A failing gcovr invocation is reported to stderr, not silently discarded"""
+    builder = _mock_builder(tmp_path)
+    gcovr = Gcovr(TargetScope.LOCAL)
+
+    with (
+        patch("fprime.fbuild.gcovr.shutil.which", return_value="/usr/bin/gcovr"),
+        patch("fprime.fbuild.gcovr.subprocess.call", return_value=1) as mock_call,
+    ):
+        gcovr.execute(builder, tmp_path, _gcovr_args())
+
+    mock_call.assert_called_once()
+    captured = capsys.readouterr()
+    assert "[ERROR]" in captured.err
+    assert "gcovr exited with code 1" in captured.err
+
+
+def test_gcovr_silent_on_success(tmp_path, capsys):
+    """A successful gcovr invocation prints no error"""
+    builder = _mock_builder(tmp_path)
+    gcovr = Gcovr(TargetScope.LOCAL)
+
+    with (
+        patch("fprime.fbuild.gcovr.shutil.which", return_value="/usr/bin/gcovr"),
+        patch("fprime.fbuild.gcovr.subprocess.call", return_value=0) as mock_call,
+    ):
+        gcovr.execute(builder, tmp_path, _gcovr_args())
+
+    mock_call.assert_called_once()
+    captured = capsys.readouterr()
+    assert "[ERROR]" not in captured.err


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes nasa/fprime#5169 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

`Gcovr.execute()` called `subprocess.call(cli_args, env=combined_env)` without capturing or checking the return code. A failing `gcovr` invocation (bad path, unexpected argument, crash) was completely invisible — the user would just see coverage results silently missing or incomplete, with no indication anything went wrong.

Now the return code is captured, and a non-zero code prints an `[ERROR] gcovr exited with code {rc}...` message to stderr, matching the style of the existing `[ERROR] Cannot find executable...` message a few lines above in the same method.

## Rationale

Fixes nasa/fprime#5169. Per the discussion there:

> I don't know that this is going to be practical. For example if for running coverage in CI ... we don't want CI to fail because coverage was too low, we still want to proceed and report the results. — @thomas-bc
>
> That's fine. I am more concerned about not catching a failure. — @bitWarrior

This only reports the failure — it does not change `execute()`'s return value or make the target itself fail. A coverage run still completes and reports whatever results it has; this just makes an already-silent process failure visible instead of invisible. I posted this plan on the issue before implementing, given the design nuance already raised there.

## Testing/Review Recommendations

- Added `test/fprime/fbuild/test_gcovr.py` with two tests: a non-zero `gcovr` exit is reported to stderr, a zero exit reports nothing. Both mock `subprocess.call` and `shutil.which` (the latter because `execute()` early-returns if `gcovr` isn't found on `PATH`, which isn't installed in my environment).
- Ran the full suite: 94 passed, 22 failed. Confirmed via `git stash` that the same 22 fail identically without this change (pre-existing, appear to be Windows-path/cmake-environment related, unrelated to this change) — so this introduces no new failures, only the 2 new passing tests.
- `black --check` clean on both changed files.
- Searched closed PRs touching `gcovr.py` first (#54, #64, #122, #137, #256, #323) — all merged, none about return-code handling, so this isn't repeating a previously-rejected approach.

## Future Work

None anticipated.
